### PR TITLE
pc-ata fix

### DIFF
--- a/ext2/block.c
+++ b/ext2/block.c
@@ -86,7 +86,7 @@ int read_blocks(uint32_t start_block, uint32_t count, void *data)
 
 	ret = ata_read(block_offset(start_block), data, ext2->block_size * count);
 
-	if (ret == ext2->block_size)
+	if (ret == ext2->block_size * count)
 		return EOK;
 	return ret;
 }

--- a/ext2/pc-ata.c
+++ b/ext2/pc-ata.c
@@ -267,6 +267,9 @@ static int ata_access(uint8_t direction, struct ata_dev *ad, uint32_t lba, uint8
 	// Send the command
 	ata_ch_write(ac, ATA_REG_COMMAND, cmd);
 
+	// Wait if busy
+	ata_polling(ac, 0);
+
 	if (direction == 0) {
 		// PIO Read
 		// Receive an iterrupt after the READ command


### PR DESCRIPTION
The lack of buys bit polling after issuing a command caused the phoenix system to crash on virtualbox.