### PR TITLE
meterfs: temporary fix for armv7-imxrt target build

### DIFF
--- a/Makefile.armv7-imxrt
+++ b/Makefile.armv7-imxrt
@@ -7,5 +7,5 @@
 #
 
 include dummyfs/Makefile
-include meterfs/Makefile
-include meterfs/test/Makefile
+#include meterfs/Makefile
+#include meterfs/test/Makefile


### PR DESCRIPTION
The spi's stm32-multi.h dependecy prevents to build meterfs on armv7-imxrt target.