### PR TITLE
dummyfs: fixed null pointer dereference

### DIFF
--- a/dummyfs/dev.c
+++ b/dummyfs/dev.c
@@ -54,6 +54,9 @@ dummyfs_object_t *dev_find(oid_t *oid, int create)
 	dummyfs_dev_t find, *entry;
 	dummyfs_object_t *o;
 
+	if (oid == NULL)
+		return NULL;
+
 	memcpy(&find.dev, oid, sizeof(oid_t));
 
 	mutexLock(dev_common.mutex);

--- a/dummyfs/dir.c
+++ b/dummyfs/dir.c
@@ -91,8 +91,7 @@ int dir_replace(dummyfs_object_t *dir, const char *name, oid_t *new)
 int dir_add(dummyfs_object_t *dir, const char *name, uint32_t mode, oid_t *oid)
 {
 	oid_t res;
-	dummyfs_dirent_t *n;
-	dummyfs_dirent_t *e = dir->entries;
+	dummyfs_dirent_t *n, *e;
 
 	if (dir == NULL)
 		return -EINVAL;
@@ -125,6 +124,7 @@ int dir_add(dummyfs_object_t *dir, const char *name, uint32_t mode, oid_t *oid)
 		return -ENOMEM;
 	}
 
+	e = dir->entries;
 	if (e == NULL) {
 		dir->entries = n;
 		n->next = n;


### PR DESCRIPTION
### dev.c
`dummyfs.c:584`
calling function `dummyfs_create`, 5th argument is `NULL`
 ```
dummyfs_create(&root, "syspage", &sysoid, S_IFDIR | 0666, NULL);
```
`dummyfs.c:405`
calling function `dev_find`, 1st argument is `NULL`
```
  o = dev_find(dev, 1);
```
`dev.c:57`
dereferencing argument `oid` that is `NULL`
```
 memcpy(&find.dev, oid, sizeof(oid_t));
```
### dir.c
Now there is first assignment, then a pointer check.
