### PR TITLE
meterfs: fixed lookup bug

### DIFF
--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -521,14 +521,10 @@ int meterfs_lookup(const char *name, id_t *res, meterfs_ctx_t *ctx)
 			break;
 	}
 
-	if (node_getByName(bname, res, &ctx->nodesTree) != NULL) {
-		node_put(*res, &ctx->nodesTree);
-
+	if (node_getByName(bname, res, &ctx->nodesTree) != NULL)
 		return i;
-	}
-	else if ((err = meterfs_getFileInfoName(bname, &f.header, ctx)) < 0) {
+	else if ((err = meterfs_getFileInfoName(bname, &f.header, ctx)) < 0)
 		return -ENOENT;
-	}
 
 	*res = err;
 


### PR DESCRIPTION
There was unneeded call of node_put() function which was causing deletion of node after it has been found in tree structure.