### PR TITLE
Fix/enhance getAttr/setAttr and add symlink creation support to ext2

### DIFF
--- a/dummyfs/dummyfs.c
+++ b/dummyfs/dummyfs.c
@@ -918,11 +918,11 @@ int main(int argc, char **argv)
 				break;
 
 			case mtSetAttr:
-				dummyfs_setattr(&msg.i.attr.oid, msg.i.attr.type, msg.i.attr.val, msg.i.data, msg.i.size);
+				msg.o.attr.err = dummyfs_setattr(&msg.i.attr.oid, msg.i.attr.type, msg.i.attr.val, msg.i.data, msg.i.size);
 				break;
 
 			case mtGetAttr:
-				dummyfs_getattr(&msg.i.attr.oid, msg.i.attr.type, &msg.o.attr.val);
+				msg.o.attr.err = dummyfs_getattr(&msg.i.attr.oid, msg.i.attr.type, &msg.o.attr.val);
 				break;
 
 			case mtLookup:

--- a/dummyfs/dummyfs.c
+++ b/dummyfs/dummyfs.c
@@ -429,8 +429,8 @@ int dummyfs_create(oid_t *dir, const char *name, oid_t *oid, uint32_t mode, oid_
 	if (S_ISLNK(mode)) {
 		const char* path = name + strlen(name) + 1;
 		object_lock(o);
-		// TODO: remove symlink if write failed
-		dummyfs_write_internal(o, 0, path, strlen(path) + 1);
+		/* TODO: remove symlink if write failed */
+		dummyfs_write_internal(o, 0, path, strlen(path));
 		object_unlock(o);
 	}
 

--- a/dummyfs/dummyfs.c
+++ b/dummyfs/dummyfs.c
@@ -69,7 +69,7 @@ int dummyfs_lookup(oid_t *dir, const char *name, oid_t *res, oid_t *dev)
 
 	if (!S_ISDIR(d->mode)) {
 		object_put(d);
-		return -EINVAL;
+		return -ENOTDIR;
 	}
 
 	object_lock(d);

--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -38,6 +38,7 @@ int ext2_create(ext2_t *fs, id_t id, const char *name, uint8_t len, oid_t *dev, 
 	if (ext2_link(fs, id, name, len, obj->id) < 0)
 		return ext2_obj_destroy(fs, obj);
 
+	/* FIXME: FIFO */
 	if (S_ISCHR(obj->inode->mode) || S_ISBLK(obj->inode->mode))
 		memcpy(&obj->dev, dev, sizeof(oid_t));
 
@@ -292,10 +293,14 @@ int ext2_getattr(ext2_t *fs, id_t id, int type, int *attr)
 	case atType:
 		if (S_ISDIR(obj->inode->mode))
 			*attr = otDir;
-		else if (S_ISCHR(obj->inode->mode) || S_ISBLK(obj->inode->mode))
-			*attr = otDev;
-		else
+		else if (S_ISREG(obj->inode->mode))
 			*attr = otFile;
+		else if (S_ISCHR(obj->inode->mode) || S_ISBLK(obj->inode->mode) || S_ISFIFO(obj->inode->mode))
+			*attr = otDev;
+		else if (S_ISLNK(obj->inode->mode))
+			*attr = otSymlink;
+		else
+			*attr = otUnknown;
 		break;
 
 	case atCTime:

--- a/ext2/libext2.c
+++ b/ext2/libext2.c
@@ -142,11 +142,11 @@ int libext2_handler(void *fdata, msg_t *msg)
 		break;
 
 	case mtGetAttr:
-		ext2_getattr(fs, msg->i.attr.oid.id, msg->i.attr.type, &msg->o.attr.val);
+		msg->o.attr.err = ext2_getattr(fs, msg->i.attr.oid.id, msg->i.attr.type, &msg->o.attr.val);
 		break;
 
 	case mtSetAttr:
-		ext2_setattr(fs, msg->i.attr.oid.id, msg->i.attr.type, msg->i.attr.val);
+		msg->o.attr.err = ext2_setattr(fs, msg->i.attr.oid.id, msg->i.attr.type, msg->i.attr.val);
 		break;
 
 	case mtLink:

--- a/jffs2/jffs2.c
+++ b/jffs2/jffs2.c
@@ -289,6 +289,8 @@ static int jffs2_srv_getattr(jffs2_partition_t *p, oid_t *oid, int type, int *at
 				*attr = otFile;
 			else if (S_ISCHR(inode->i_mode))
 				*attr = otDev;
+			else if (S_ISLNK(inode->i_mode))
+				*attr = otSymlink;
 			else
 				*attr = otUnknown;
 			break;

--- a/jffs2/jffs2.c
+++ b/jffs2/jffs2.c
@@ -900,11 +900,11 @@ int jffs2lib_message_handler(void *partition, msg_t *msg)
 		break;
 
 	case mtSetAttr:
-		msg->o.attr.val = jffs2_srv_setattr(p, &msg->i.attr.oid, msg->i.attr.type, msg->i.attr.val, msg->i.data, msg->i.size);
+		msg->o.attr.err = jffs2_srv_setattr(p, &msg->i.attr.oid, msg->i.attr.type, msg->i.attr.val, msg->i.data, msg->i.size);
 		break;
 
 	case mtGetAttr:
-		jffs2_srv_getattr(p, &msg->i.attr.oid, msg->i.attr.type, &msg->o.attr.val);
+		msg->o.attr.err = jffs2_srv_getattr(p, &msg->i.attr.oid, msg->i.attr.type, &msg->o.attr.val);
 		break;
 
 	case mtLookup:


### PR DESCRIPTION
## Description
Needed for `realpath()` to work sensibly.

## Motivation and Context
JIRA: DTR-75
https://github.com/phoenix-rtos/phoenix-rtos-project/issues/112

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/29
- [x] Tested by hand on: **ia32-generic** (ext2), **DTR** (jffs2, dummyfs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work: https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/204
- [x] I will merge this PR by myself when appropriate.