### PR TITLE
ext2: fix fs->root filesystem object initialization

### DIFF
--- a/ext2/obj.c
+++ b/ext2/obj.c
@@ -329,6 +329,7 @@ int ext2_objs_init(ext2_t *fs)
 	lib_rbInit(&objs->used, ext2_obj_cmp, NULL);
 
 	fs->objs = objs;
+	fs->root = NULL;
 
 	return EOK;
 }


### PR DESCRIPTION
## Description
Added fs->root NULL initialization.

## Motivation and Context
Mounting ext2 filesystem caused page fault exception (the problem appeared while developing new plo ia32-generic implementation).
[JIRA issue](https://jira.phoenix-rtos.com/browse/RTOS-66)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment
- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
