### PR TITLE
dummyfs: fix dir nonexistent errno (EINVAL -> ENOTDIR)

### DIFF
--- a/dummyfs/dir.c
+++ b/dummyfs/dir.c
@@ -30,7 +30,7 @@ int dir_find(dummyfs_object_t *dir, const char *name, oid_t *res)
 	int len;
 
 	if (!S_ISDIR(dir->mode))
-		return -EINVAL;
+		return -ENOTDIR;
 
 	if (e == NULL)
 		return -ENOENT;
@@ -64,7 +64,7 @@ int dir_replace(dummyfs_object_t *dir, const char *name, oid_t *new)
 	char *end = strchr(dirname, '/');
 
 	if (!S_ISDIR(dir->mode))
-		return -EINVAL;
+		return -ENOTDIR;
 
 	if (e == NULL)
 		return -ENOENT;


### PR DESCRIPTION
## Description
Fixes invalid some invalid errnos in dummyfs.

## Motivation and Context
JIRA: DTR-75

Needed for https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/29 to pass if `/etc` lies on `dummyfs`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/29
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
