### PR TITLE
dummyfs: memory-related fixes

### DIFF
--- a/dummyfs/dummyfs.c
+++ b/dummyfs/dummyfs.c
@@ -370,7 +370,7 @@ int dummyfs_unlink(oid_t *dir, const char *name)
 		object_unlock(d);
 		object_put(d);
 		object_put(o);
-		return -EINVAL;
+		return -ENOTEMPTY;
 	}
 
 	ret = dir_remove(d, name);

--- a/dummyfs/dummyfs.h
+++ b/dummyfs/dummyfs.h
@@ -23,6 +23,9 @@
 
 #define DUMMYFS_SIZE_MAX 32 * 1024 * 1024
 
+/* threshold for cleaning directory from deleted dirents */
+#define DUMMYFS_DIRTY_DIR_AUTOCLEANUP_THRESH 8
+
 
 typedef struct _dummyfs_dirent_t {
 	char *name;

--- a/dummyfs/object.c
+++ b/dummyfs/object.c
@@ -57,6 +57,7 @@ dummyfs_object_t *object_create(void)
 	}
 
 	if (dummyfs_incsz(sizeof(dummyfs_object_t)) != EOK) {
+		free(r);
 		mutexUnlock(dummyfs_common.mutex);
 		mutexUnlock(olock);
 		return NULL;


### PR DESCRIPTION
## Description
 - dummyfs: fix memory leaks
   - deleted dirents for dummyfs root dir were never freed
   - fixed memory leaks in error paths
   - fixed ERRNO value
 - dummyfs: fix realloc() usage
   Also: remove unneeded chunk properly.

## Motivation and Context
Fixes phoenix-rtos/phoenix-rtos-project#169


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
