### PR TITLE
meterfs: remove partitionErase() usage + mark it as deprecated

### DIFF
--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -105,10 +105,15 @@ static int meterfs_checkfs(meterfs_ctx_t *ctx)
 
 	if (!valid0 && !valid1) {
 		LOG_INFO("meterfs: No valid filesystem detected. Formating.");
-		if ((err = ctx->partitionErase()) < 0) {
+		if ((err = meterfs_eraseFileTable(0, ctx)) < 0) {
 			meterfs_powerctrl(0, ctx);
 			return err;
 		}
+		if ((err = meterfs_eraseFileTable(1, ctx)) < 0) {
+			meterfs_powerctrl(0, ctx);
+			return err;
+		}
+
 		ctx->filecnt = 0;
 		ctx->hcurrAddr = 0;
 
@@ -885,7 +890,11 @@ int meterfs_devctl(meterfs_i_devctl_t *i, meterfs_o_devctl_t *o, meterfs_ctx_t *
 
 		case meterfs_chiperase:
 			meterfs_powerctrl(1, ctx);
-			if ((err = ctx->partitionErase()) < 0) {
+			if ((err = meterfs_eraseFileTable(0, ctx)) < 0) {
+				meterfs_powerctrl(0, ctx);
+				return err;
+			}
+			if ((err = meterfs_eraseFileTable(1, ctx)) < 0) {
 				meterfs_powerctrl(0, ctx);
 				return err;
 			}

--- a/meterfs/meterfs.h
+++ b/meterfs/meterfs.h
@@ -71,7 +71,7 @@ typedef struct {
 	ssize_t (*read)(unsigned int addr, void *buff, size_t bufflen);
 	ssize_t (*write)(unsigned int addr, void *buff, size_t bufflen);
 	int (*eraseSector)(unsigned int addr);
-	int (*partitionErase)(void);
+	int (*partitionErase)(void); /* Deprecated, TODO: remove all partitionErase() occurrences */
 	void (*powerCtrl)(int state);
 } meterfs_ctx_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-182](https://jira.phoenix-rtos.com/browse/DTR-182)
[JIRA: DTR-184](https://jira.phoenix-rtos.com/browse/DTR-184)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
