### PR TITLE
Add 'atBlocks' and 'atIOBlock' attributes support

### DIFF
--- a/dummyfs/dummyfs.c
+++ b/dummyfs/dummyfs.c
@@ -197,6 +197,15 @@ int dummyfs_getattr(void *ctx, oid_t *oid, int type, long long *attr)
 			*attr = o->size;
 			break;
 
+		case (atBlocks):
+			*attr = (o->size + S_BLKSIZE - 1) / S_BLKSIZE;
+			break;
+
+		case (atIOBlock):
+			/* TODO: determine optimal I/O block size */
+			*attr = 1;
+			break;
+
 		case (atType):
 			if (S_ISDIR(o->mode))
 				*attr = otDir;

--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -290,6 +290,16 @@ int ext2_getattr(ext2_t *fs, id_t id, int type, long long *attr)
 		*attr = obj->inode->size;
 		break;
 
+	case atBlocks:
+		*attr = obj->inode->blocks;
+		break;
+
+	case atIOBlock:
+		/* TODO: determine optimal I/O block size */
+		/* fs->blocksz seems reasonable for now */
+		*attr = fs->blocksz;
+		break;
+
 	case atType:
 		if (S_ISDIR(obj->inode->mode))
 			*attr = otDir;

--- a/jffs2/jffs2.c
+++ b/jffs2/jffs2.c
@@ -282,6 +282,15 @@ static int jffs2_srv_getattr(jffs2_partition_t *p, oid_t *oid, int type, long lo
 			*attr = inode->i_size;
 			break;
 
+		case (atBlocks):
+			*attr = inode->i_blocks;
+			break;
+
+		case (atIOBlock):
+			/* TODO: determine optimal I/O block size */
+			*attr = 1;
+			break;
+
 		case (atType): /* type */
 			if (S_ISDIR(inode->i_mode))
 				*attr = otDir;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added support for retrieving stat.st_blocks and stat.st_blksize info.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-205](https://jira.phoenix-rtos.com/browse/DTR-205)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic (ext2), armv7a7-imx6ull (jffs2).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/283
https://github.com/phoenix-rtos/libphoenix/pull/156
- [ ] I will merge this PR by myself when appropriate.
