### PR TITLE
Restrict setting file mode (atMode attribute) to permission bits only

### DIFF
--- a/dummyfs/dummyfs.c
+++ b/dummyfs/dummyfs.c
@@ -143,7 +143,7 @@ int dummyfs_setattr(void *ctx, oid_t *oid, int type, long long attr, const void 
 			break;
 
 		case (atMode):
-			o->mode = attr;
+			o->mode = (o->mode & ~0777) | (attr & 0777);
 			break;
 
 		case (atSize):

--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -353,7 +353,7 @@ int ext2_setattr(ext2_t *fs, id_t id, int type, long long attr)
 
 	switch(type) {
 	case atMode:
-		obj->inode->mode |= (attr & 0x1ff);
+		obj->inode->mode = (obj->inode->mode & ~0777) | (attr & 0777);
 		break;
 
 	case atUid:

--- a/jffs2/jffs2.c
+++ b/jffs2/jffs2.c
@@ -207,7 +207,7 @@ static int jffs2_srv_setattr(jffs2_partition_t *p, oid_t *oid, int type, long lo
 
 		case (atMode): /* mode */
 			iattr.ia_valid = ATTR_MODE;
-			iattr.ia_mode = (inode->i_mode & ~0xffff) | (attr & 0xffff);
+			iattr.ia_mode = (inode->i_mode & ~0777) | (attr & 0777);
 			break;
 
 		case (atUid): /* uid */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
`atMode` message should set file attributes only. It shouldn't modify file type bits.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-206](https://jira.phoenix-rtos.com/browse/DTR-206)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic, armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment
- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/285
- [ ] I will merge this PR by myself when appropriate.
