### PR TITLE
ext2: unlink not empty dir correct errno

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -501,7 +501,7 @@ int ext2_unlink(ext2_t *fs, id_t id, const char *name, uint8_t len)
 			}
 
 			if (S_ISDIR(obj->inode->mode) && !_ext2_dir_empty(fs, obj)) {
-				err = -EACCES;
+				err = -ENOTEMPTY;
 				break;
 			}
 


### PR DESCRIPTION
JIRA: PD-236

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
ext2 currently returns `EACCES` when called on directory that is not empty. `ENOTEMPTY` may be more appropriate solution.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/288 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
