### PR TITLE
jffs2: adapt to imx6ull-flash driver interface change

### DIFF
--- a/jffs2/phoenix-rtos/mtd.c
+++ b/jffs2/phoenix-rtos/mtd.c
@@ -342,7 +342,7 @@ struct dentry *mount_mtd(struct file_system_type *fs_type, int flags,
 		int (*fill_super)(struct super_block *, void *, int))
 {
 	struct mtd_info *mtd;
-	flashdrv_dma_t *dma;
+	flashdrv_dmaBuff_t *dma;
 	jffs2_partition_t *p = (jffs2_partition_t *)data;
 
 	mtd = malloc(sizeof(struct mtd_info));

--- a/jffs2/phoenix-rtos/mtd.h
+++ b/jffs2/phoenix-rtos/mtd.h
@@ -79,7 +79,7 @@ struct mtd_info {
 	uint64_t size;
 	uint32_t oobsize;
 	uint32_t oobavail;
-	flashdrv_dma_t *dma;
+	flashdrv_dmaBuff_t *dma;
 	void *data_buf;
 	void *meta_buf;
 	uint32_t start;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Struct `flashdrv_dma_t` got renamed to `flashdrv_dmaBuff_t`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-169](https://jira.phoenix-rtos.com/browse/DTR-169)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/194
- [ ] I will merge this PR by myself when appropriate.
