### PR TITLE
jffs2: change RW semaphore implementation to mutex-based one (enables priority inheritance)

### DIFF
--- a/jffs2/phoenix-rtos/locks.h
+++ b/jffs2/phoenix-rtos/locks.h
@@ -48,12 +48,9 @@ static inline bool mutex_is_locked(struct mutex *lock)
 
 
 struct rw_semaphore {
-	handle_t	lock;
-	handle_t	rcond;
-	handle_t	wcond;
-	uint32_t		cnt;
-	uint32_t		rwait;
-	uint32_t		wwait;
+	unsigned int rcnt; /* Number of active readers */
+	handle_t rlock;    /* Readers lock, protects rcnt */
+	handle_t wlock;    /* Writers lock, ensures their mutual exclusion */
 };
 
 extern void up_read(struct rw_semaphore *sem);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed RW semaphore implementation to one enabling priority inheritance. It still has 2 significant drawbacks:
1. the writers may get starved by the readers,
2. the current writer may inherit priority from the first reader only,
Should be addressed and fixed by RW semaphore implementation in kernel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-318](https://jira.phoenix-rtos.com/browse/DTR-318)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
