### PR TITLE
Fix `du` on `jffs2`

### DIFF
--- a/dummyfs/dummyfs.c
+++ b/dummyfs/dummyfs.c
@@ -169,10 +169,14 @@ int dummyfs_setattr(void *ctx, oid_t *oid, int type, long long attr, const void 
 		case (atATime):
 			o->atime = attr;
 			break;
+
+		default:
+			ret = -EINVAL;
+			break;
 	}
 
 	/* FIXME: mtime and atime are always set together */
-	if (type != atMTime && type != atATime)
+	if (ret == EOK && type != atMTime && type != atATime)
 		o->mtime = time(NULL);
 
 	object_unlock(fs, o);
@@ -186,6 +190,7 @@ int dummyfs_getattr(void *ctx, oid_t *oid, int type, long long *attr)
 {
 	dummyfs_t *fs = (dummyfs_t *)ctx;
 	dummyfs_object_t *o;
+	int ret = EOK;
 
 	if ((o = dummyfs_get(fs, oid)) == NULL)
 		return -ENOENT;
@@ -255,12 +260,16 @@ int dummyfs_getattr(void *ctx, oid_t *oid, int type, long long *attr)
 			// trivial implementation: assume read/write is always possible
 			*attr = POLLIN|POLLRDNORM|POLLOUT|POLLWRNORM;
 			break;
+
+		default:
+			ret = -EINVAL;
+			break;
 	}
 
 	object_unlock(fs, o);
 	object_put(fs, o);
 
-	return EOK;
+	return ret;
 }
 
 // allow overriding files by link() to support naive rename() implementation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes `du` tool on `jffs2` filesystem. Actually, the resulting file sizes were a cummulation of 2 errors, fixed in separate commits:
* all-fs: fix getting/setting unknown attrs resulting in EOK
* jffs2: fix missing atBlocks, atIOBlock getattr

## Motivation and Context
I want `du` to work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
