### PR TITLE
dummyfs: add mounting capabilities to dummyfs

### DIFF
--- a/dummyfs/dev.h
+++ b/dummyfs/dev.h
@@ -18,7 +18,10 @@
 #include "dummyfs_internal.h"
 #include "object.h"
 
-extern dummyfs_object_t *dev_find(dummyfs_t *ctx, oid_t *oid, int create);
+extern dummyfs_object_t *dev_find(dummyfs_t *ctx, oid_t *oid);
+
+
+extern int dev_create(dummyfs_t *ctx, oid_t *oid, dummyfs_object_t *obj);
 
 
 extern int dev_destroy(dummyfs_t *ctx, oid_t *oid);

--- a/dummyfs/dummyfs_internal.h
+++ b/dummyfs/dummyfs_internal.h
@@ -87,6 +87,7 @@ typedef struct {
 	rbtree_t devtree;
 	handle_t devlock;
 	char *mountpt;
+	oid_t parent;
 } dummyfs_t;
 
 int dummyfs_incsz(dummyfs_t *ctx, int size);


### PR DESCRIPTION
JIRA: RTOS-255

Dummyfs is now able to mount other filesystems.

## Description
In lookup added checking for mountpoints, also now lookup sets correct oid->dev.
In dev_find added changes that allow to correctly assign object with device.

## Motivation and Context
This change was required for dummyfs to be able to mount other filesystems.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
