### PR TITLE
ext2: handle setting atime/mtime attributes

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -381,6 +381,14 @@ int ext2_setattr(ext2_t *fs, id_t id, int type, long long attr)
 			break;
 		break;
 
+	case atMTime:
+		obj->inode->mtime = attr;
+		break;
+
+	case atATime:
+		obj->inode->atime = attr;
+		break;
+
 	default:
 		/* unknown / invalid attribute to set */
 		err = -EINVAL;
@@ -388,7 +396,10 @@ int ext2_setattr(ext2_t *fs, id_t id, int type, long long attr)
 	}
 
 	if (err == EOK) {
-		obj->inode->mtime = obj->inode->atime = time(NULL);
+		if (type != atMTime && type != atATime) {
+			obj->inode->mtime = obj->inode->atime = time(NULL);
+		}
+
 		obj->flags |= OFLAG_DIRTY;
 		err = _ext2_obj_sync(fs, obj);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - ext2: handle setting atime/mtime attributes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - fixes touch on existing file (currently not working on ia32-generic)

 - JIRA: PD-304


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
