### PR TITLE
jffs2: fix file attributes

### DIFF
--- a/jffs2/phoenix-rtos/fs.h
+++ b/jffs2/phoenix-rtos/fs.h
@@ -165,6 +165,7 @@ static inline int dir_print(struct dir_context *ctx, const char *name, int len, 
 			break;
 		case DT_CHR:
 		case DT_BLK:
+		case DT_FIFO:
 			ctx->dent->d_type = otDev;
 			break;
 		case DT_LNK:

--- a/jffs2/phoenix-rtos/phoenix-rtos.c
+++ b/jffs2/phoenix-rtos/phoenix-rtos.c
@@ -266,7 +266,7 @@ void *kmemdup(const void *src, size_t len, unsigned gfp)
 
 unsigned long get_seconds(void)
 {
-	return 0;
+	return time(NULL);
 }
 
 bool kthread_should_stop(void)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixed setting newly created file attributes (they were previously hardcoded).
Fixed setting file atime, mtime and ctime by addding `get_seconds()` implementation (previously returned 0).
Fixed device file type (character, block or fifo) to `otDev` conversion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-368](https://jira.phoenix-rtos.com/browse/DTR-368)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
