### PR TITLE
ext2: Fix _ext2_dir_read() skipping last entries in a directory

### DIFF
--- a/ext2/dir.c
+++ b/ext2/dir.c
@@ -129,9 +129,16 @@ int _ext2_dir_read(ext2_t *fs, ext2_obj_t *dir, offs_t offs, struct dirent *res,
 	if ((entry = (ext2_dirent_t *)malloc(len)) == NULL)
 		return -ENOMEM;
 
-	if ((ret = _ext2_file_read(fs, dir, offs, (char *)entry, len)) != len) {
+	ret = _ext2_file_read(fs, dir, offs, (char *)entry, len);
+
+	if (ret < (ssize_t)sizeof(ext2_dirent_t)) {
 		free(entry);
 		return (ret < 0) ? (int)ret : -ENOENT;
+	}
+
+	if (ret < (ssize_t)(sizeof(ext2_dirent_t) + entry->len)) {
+		free(entry);
+		return -ENOENT;
 	}
 
 	if (!entry->len) {


### PR DESCRIPTION
DONE: RTOS-322

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
