### PR TITLE
dummyfs: Remove NULL check from read/write

### DIFF
--- a/dummyfs/file.c
+++ b/dummyfs/file.c
@@ -156,7 +156,7 @@ int dummyfs_write_internal(dummyfs_t *ctx, dummyfs_object_t *o, offs_t offs, con
 	int ret = EOK;
 
 	if (len == 0) {
-		return EOK;
+		return 0;
 	}
 
 	if (offs + len > o->size) {


### PR DESCRIPTION
There is zero reason for us to check for NULL buffer - as it is not possible to receive buff == NULL and len != 0 from msg. Regarding use outside of standard server - there is no reason to pass same parameter combo, so there's no need to check for it. There many other invalid pointers apart from NULL, we can't check for them all anyway (other than try and crash).

DONE: RTOS-353

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/598

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
