### PR TITLE
meterfs: Add fsInfo devctl

### DIFF
--- a/meterfs/files.h
+++ b/meterfs/files.h
@@ -16,8 +16,8 @@
 
 #include <stdint.h>
 
-#define HGRAIN            32 /* Must be able divide sector size */
-#define HEADER_SECTOR_CNT 2
+#define HGRAIN            32u /* Must be able divide sector size */
+#define HEADER_SECTOR_CNT 2u
 #define HEADER_SIZE(ssz)  (HEADER_SECTOR_CNT * (ssz))
 #define MAX_FILE_CNT(ssz) ((HEADER_SIZE(ssz) - HGRAIN) / HGRAIN)
 

--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -25,10 +25,10 @@
 #include "files.h"
 #include "node.h"
 
-#define TOTAL_SIZE(f)        (((f)->filesz / (f)->recordsz) * ((f)->recordsz + sizeof(entry_t)))
-#define SECTORS(f, sectorsz) (((TOTAL_SIZE(f) + (sectorsz)-1) / (sectorsz)) + 1)
-
 /* clang-format off */
+#define TOTAL_SIZE(f)        (((f)->filesz / (f)->recordsz) * ((f)->recordsz + sizeof(entry_t)))
+#define SECTORS(f, sectorsz) (((TOTAL_SIZE(f) + (sectorsz) - 1) / (sectorsz)) + 1)
+
 #define LOG_INFO(str, ...) do { if(1) printf(str "\n", ##__VA_ARGS__); } while(0)
 #define LOG_DEBUG(str, ...) do { if(0) printf(str "\n", ##__VA_ARGS__); } while(0)
 /* clang-format on */
@@ -1189,6 +1189,7 @@ int meterfs_writeFile(id_t id, const char *buff, size_t bufflen, meterfs_ctx_t *
 
 	return err;
 }
+
 
 static int meterfs_doDevctl(const meterfs_i_devctl_t *i, meterfs_o_devctl_t *o, meterfs_ctx_t *ctx)
 {

--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -26,7 +26,7 @@
 #include "node.h"
 
 #define TOTAL_SIZE(f)        (((f)->filesz / (f)->recordsz) * ((f)->recordsz + sizeof(entry_t)))
-#define SECTORS(f, sectorsz) (((TOTAL_SIZE(f) + (sectorsz) - 1) / (sectorsz)) + 1)
+#define SECTORS(f, sectorsz) (((TOTAL_SIZE(f) + (sectorsz)-1) / (sectorsz)) + 1)
 
 /* clang-format off */
 #define LOG_INFO(str, ...) do { if(1) printf(str "\n", ##__VA_ARGS__); } while(0)
@@ -664,7 +664,7 @@ static int meterfs_getFilePos(file_t *f, meterfs_ctx_t *ctx)
 		return 0;
 
 	/* Find newest record */
-	for (interval = totalrecord - 1; interval != 0; ) {
+	for (interval = totalrecord - 1; interval != 0;) {
 		idx = ((f->lastoff / (f->header.recordsz + sizeof(entry_t))) + interval) % totalrecord;
 		offset = idx * (f->header.recordsz + sizeof(entry_t));
 		err = ctx->read(ctx->offset + baddr + offset + offsetof(entry_t, id), &id, sizeof(id));
@@ -689,7 +689,7 @@ static int meterfs_getFilePos(file_t *f, meterfs_ctx_t *ctx)
 	diff -= maxrecord;
 
 	/* Find oldest record */
-	for (interval = diff; interval != 0 && diff != 0; ) {
+	for (interval = diff; interval != 0 && diff != 0;) {
 		idx = (int)(f->firstoff / (f->header.recordsz + sizeof(entry_t))) + interval;
 		if (idx < 0)
 			idx += totalrecord;
@@ -1252,6 +1252,14 @@ int meterfs_devctl(meterfs_i_devctl_t *i, meterfs_o_devctl_t *o, meterfs_ctx_t *
 			o->info.filesz = p->header.filesz;
 			o->info.recordsz = p->header.recordsz;
 			o->info.recordcnt = p->recordcnt;
+
+			break;
+
+		case meterfs_devInfo:
+			o->fsInfo.sectorsz = ctx->sectorsz;
+			o->fsInfo.sz = ctx->sz;
+			o->fsInfo.filecnt = ctx->filecnt;
+			o->fsInfo.fileLimit = MAX_FILE_CNT(ctx->sectorsz);
 
 			break;
 

--- a/meterfs/meterfs.h
+++ b/meterfs/meterfs.h
@@ -19,7 +19,7 @@
 #define MAX_NAME_LEN 8
 
 
-enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_devInfo, meterfs_chiperase };
+enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_fsInfo, meterfs_chiperase };
 
 
 typedef struct {
@@ -108,7 +108,7 @@ int meterfs_readFile(id_t id, off_t off, char *buff, size_t bufflen, meterfs_ctx
 int meterfs_writeFile(id_t id, const char *buff, size_t bufflen, meterfs_ctx_t *ctx);
 
 
-int meterfs_devctl(meterfs_i_devctl_t *i, meterfs_o_devctl_t *o, meterfs_ctx_t *ctx);
+int meterfs_devctl(const meterfs_i_devctl_t *i, meterfs_o_devctl_t *o, meterfs_ctx_t *ctx);
 
 
 #endif

--- a/meterfs/meterfs.h
+++ b/meterfs/meterfs.h
@@ -19,7 +19,7 @@
 #define MAX_NAME_LEN 8
 
 
-enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_chiperase };
+enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_devInfo, meterfs_chiperase };
 
 
 typedef struct {
@@ -45,12 +45,20 @@ typedef struct {
 
 typedef struct {
 	int err;
+	
 	struct _info {
 		size_t sectors;
 		size_t filesz;
 		size_t recordsz;
 		size_t recordcnt;
 	} info;
+
+	struct {
+		size_t sz;
+		size_t sectorsz;
+		size_t fileLimit;
+		size_t filecnt;
+	} fsInfo;
 } meterfs_o_devctl_t;
 
 

--- a/meterfs/meterfs.h
+++ b/meterfs/meterfs.h
@@ -18,9 +18,9 @@
 
 #define MAX_NAME_LEN 8
 
-
-enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_fsInfo, meterfs_chiperase };
-
+/* clang-format off */
+enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_chiperase, meterfs_fsInfo };
+/* clang-format on */
 
 typedef struct {
 	int type;
@@ -45,7 +45,7 @@ typedef struct {
 
 typedef struct {
 	int err;
-	
+
 	struct _info {
 		size_t sectors;
 		size_t filesz;


### PR DESCRIPTION
JIRA: RTOS-361

## Description
Adds devctl returning info about filesystem to meterfs.

## Motivation and Context
This change helps write more general meterfs tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/162.
- [x] Tested by hand on: host-generic-pc, imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
