### PR TITLE
remove LIBS sets before calling static-lib.mk

### DIFF
--- a/jffs2/Makefile
+++ b/jffs2/Makefile
@@ -59,6 +59,4 @@ ifeq ($(CONFIG_JFFS2_LZO), 1)
   LOCAL_SRCS += compr_lzo.c
 endif
 
-LIBS := libstorage libmtd
-
 include $(static-lib.mk)


### PR DESCRIPTION
LIBS is not used in static-lib and this value can corrupt next binary.mk

This needs to be merged before https://github.com/phoenix-rtos/phoenix-rtos-build/pull/144