### PR TITLE
_targets: add libdummyfs for imxrt targets

### DIFF
--- a/_targets/Makefile.armv7m7-imxrt106x
+++ b/_targets/Makefile.armv7m7-imxrt106x
@@ -16,4 +16,4 @@ else ifneq (, $(findstring 106, $(TARGET)))
   CFLAGS += -DTARGET_IMXRT1060
 endif
 
-DEFAULT_COMPONENTS := dummyfs libmeterfs
+DEFAULT_COMPONENTS := dummyfs libdummyfs libmeterfs


### PR DESCRIPTION
Adds `libdummyfs` for optional support to be built into `imxrt-multi`.

The classic dummyfs server is also built independently depending on that how memory is divided and how booting is done, whether from xip or ram, it is left to the project implementer to choose whether to use either a clasic dummyfs server or imxrt-multi with dummyfs embedded.

JIRA: NIL-432

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: nil-imxrt1176
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
