### PR TITLE
makes: remove TARGET define

### DIFF
--- a/_targets/Makefile.armv7m3-stm32l152xd
+++ b/_targets/Makefile.armv7m3-stm32l152xd
@@ -6,6 +6,7 @@
 # Copyright 2020 Phoenix Systems
 #
 
+# FIXME: on STM32L1 TARGET, __TARGET and __CPU are not supported
 CFLAGS += -DTARGET_STM32 -DTARGET_STM32L1
 
 DEFAULT_COMPONENTS := meterfs

--- a/_targets/Makefile.armv7m4-stm32l4x6
+++ b/_targets/Makefile.armv7m4-stm32l4x6
@@ -6,6 +6,4 @@
 # Copyright 2020 Phoenix Systems
 #
 
-CFLAGS += -DTARGET_STM32 -DTARGET_STM32L4
-
 DEFAULT_COMPONENTS := libdummyfs dummyfs libmeterfs

--- a/_targets/Makefile.armv7m7-imxrt106x
+++ b/_targets/Makefile.armv7m7-imxrt106x
@@ -6,14 +6,5 @@
 # Copyright 2020 Phoenix Systems
 #
 #
-CFLAGS += -DTARGET_IMXRT
-
-ifneq (, $(findstring 117, $(TARGET)))
-  CFLAGS += -DTARGET_IMXRT1170
-else ifneq (, $(findstring 105, $(TARGET)))
-  CFLAGS += -DTARGET_IMXRT1050
-else ifneq (, $(findstring 106, $(TARGET)))
-  CFLAGS += -DTARGET_IMXRT1060
-endif
 
 DEFAULT_COMPONENTS := dummyfs libdummyfs libmeterfs


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Each target now have access to global `__TARGET_*` and `__CPU_*` defined by phoenix-rtos-build system. Local TARGET defines becomes redundant, especially if they haven't been used.

JIRA: RTOS-519


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176-nil, imxrt1064-evk, ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
