### PR TITLE
jffs2: fix readdir returned direntry d_type

### DIFF
--- a/jffs2/phoenix-rtos/fs.h
+++ b/jffs2/phoenix-rtos/fs.h
@@ -146,25 +146,7 @@ static inline bool dir_emit_dots(struct file *file, struct dir_context *ctx)
 
 static inline int dir_print(struct dir_context *ctx, const char *name, int len, loff_t pos, uint64_t ino, unsigned type)
 {
-	switch (type) {
-		case DT_REG:
-			ctx->dent->d_type = otFile;
-			break;
-		case DT_DIR:
-			ctx->dent->d_type = otDir;
-			break;
-		case DT_CHR:
-		case DT_BLK:
-		case DT_FIFO:
-			ctx->dent->d_type = otDev;
-			break;
-		case DT_LNK:
-			ctx->dent->d_type = otSymlink;
-			break;
-		default:
-			ctx->dent->d_type = otUnknown;
-	}
-
+	ctx->dent->d_type = type;
 	ctx->pos++;
 	ctx->emit++;
 	ctx->dent->d_namlen = len;


### PR DESCRIPTION
## Motivation and Context

Remnant of switching globally to LSB d_types.

Fixes: phoenix-rtos/phoenix-rtos-project#889

<!--- Provide a general summary of your changes in the Title above -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `zynq-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
