### PR TITLE
ext2: add compatibility with libstorage

### DIFF
--- a/_targets/Makefile.armv7a9-zynq7000
+++ b/_targets/Makefile.armv7a9-zynq7000
@@ -6,4 +6,4 @@
 # Copyright 2021 Phoenix Systems
 #
 
-DEFAULT_COMPONENTS := dummyfs libjffs2
+DEFAULT_COMPONENTS := dummyfs libjffs2 libext2

--- a/ext2/block.c
+++ b/ext2/block.c
@@ -24,9 +24,19 @@
 int ext2_block_read(ext2_t *fs, uint32_t bno, void *buff, uint32_t n)
 {
 	ssize_t size = n * fs->blocksz;
-
-	if (fs->read(fs->oid.id, bno * fs->blocksz, buff, size) != size)
-		return -EIO;
+	if (fs->strg != NULL) {
+		if (fs->strg->dev->blk->ops->read(fs->strg, fs->strg->start + bno * fs->blocksz, buff, size) != size) {
+			return -EIO;
+		}
+	}
+	else if (fs->legacy.read != NULL) {
+		if (fs->legacy.read(fs->legacy.devId, bno * fs->blocksz, buff, size) != size) {
+			return -EIO;
+		}
+	}
+	else {
+		return -ENOSYS;
+	}
 
 	return EOK;
 }
@@ -35,9 +45,19 @@ int ext2_block_read(ext2_t *fs, uint32_t bno, void *buff, uint32_t n)
 int ext2_block_write(ext2_t *fs, uint32_t bno, const void *buff, uint32_t n)
 {
 	ssize_t size = n * fs->blocksz;
-
-	if (fs->write(fs->oid.id, bno * fs->blocksz, buff, size) != size)
-		return -EIO;
+	if (fs->strg != NULL) {
+		if (fs->strg->dev->blk->ops->write(fs->strg, fs->strg->start + bno * fs->blocksz, buff, size) != size) {
+			return -EIO;
+		}
+	}
+	else if (fs->legacy.write != NULL) {
+		if (fs->legacy.write(fs->legacy.devId, bno * fs->blocksz, buff, size) != size) {
+			return -EIO;
+		}
+	}
+	else {
+		return -ENOSYS;
+	}
 
 	return EOK;
 }

--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -74,12 +74,13 @@ int ext2_destroy(ext2_t *fs, id_t id)
 }
 
 
-int ext2_lookup(ext2_t *fs, id_t id, const char *name, uint8_t len, id_t *res, oid_t *dev)
+int ext2_lookup(ext2_t *fs, id_t id, const char *name, uint8_t len, oid_t *res, oid_t *dev)
 {
 	ext2_obj_t *dir, *obj = NULL;
 	uint8_t i, j;
 	int err;
 
+	res->port = fs->port;
 	if (!len || (name == NULL))
 		return -EINVAL;
 
@@ -108,10 +109,10 @@ int ext2_lookup(ext2_t *fs, id_t id, const char *name, uint8_t len, id_t *res, o
 				break;
 			}
 
-			if ((err = _ext2_dir_search(fs, dir, name + i, j - i, res)) < 0)
+			if ((err = _ext2_dir_search(fs, dir, name + i, j - i, &res->id)) < 0)
 				break;
 
-			if ((obj = ext2_obj_get(fs, *res)) == NULL) {
+			if ((obj = ext2_obj_get(fs, res->id)) == NULL) {
 				ext2_unlink(fs, dir->id, name + i, j - i);
 				err = -ENOENT;
 				break;
@@ -131,8 +132,8 @@ int ext2_lookup(ext2_t *fs, id_t id, const char *name, uint8_t len, id_t *res, o
 		memcpy(dev, &obj->dev, sizeof(oid_t));
 	}
 	else {
-		dev->port = fs->oid.port;
-		dev->id = *res;
+		dev->port = fs->port;
+		dev->id = res->id;
 	}
 
 	mutexUnlock(obj->lock);

--- a/ext2/ext2.h
+++ b/ext2/ext2.h
@@ -19,6 +19,8 @@
 #include <limits.h>
 #include <stdint.h>
 
+#include <storage/storage.h>
+
 #include <sys/types.h>
 
 
@@ -29,9 +31,9 @@
 
 
 /* Filesystem common data types forward declaration */
-typedef struct _ext2_sb_t   ext2_sb_t;   /* SuperBlock */
-typedef struct _ext2_gd_t   ext2_gd_t;   /* Group Descriptor*/
-typedef struct _ext2_obj_t  ext2_obj_t;  /* Filesystem object */
+typedef struct _ext2_sb_t ext2_sb_t;     /* SuperBlock */
+typedef struct _ext2_gd_t ext2_gd_t;     /* Group Descriptor*/
+typedef struct _ext2_obj_t ext2_obj_t;   /* Filesystem object */
 typedef struct _ext2_objs_t ext2_objs_t; /* Filesystem objects */
 
 
@@ -43,11 +45,15 @@ typedef ssize_t (*dev_write)(id_t, offs_t, const char *, size_t);
 typedef struct {
 	/* Device info */
 	uint32_t sectorsz; /* Device sector size */
-	dev_read read;     /* Device read callback */
-	dev_write write;   /* Device write callback */
+	storage_t *strg;   /* Pointer to libstorage data */
+	struct {
+		id_t devId;      /* Device ID for reading */
+		dev_read read;   /* Device read callback */
+		dev_write write; /* Device write callback */
+	} legacy;
 
 	/* Filesystem info */
-	oid_t oid;         /* Filesystem port and device ID */
+	unsigned int port; /* Filesystem port */
 	ext2_sb_t *sb;     /* SuperBlock */
 	ext2_gd_t *gdt;    /* Group Descriptors Table */
 	uint32_t blocksz;  /* Block size */
@@ -74,7 +80,7 @@ extern int ext2_destroy(ext2_t *fs, id_t id);
 
 
 /* Lookups a file */
-extern int ext2_lookup(ext2_t *fs, id_t id, const char *name, uint8_t len, id_t *res, oid_t *dev);
+extern int ext2_lookup(ext2_t *fs, id_t id, const char *name, uint8_t len, oid_t *res, oid_t *dev);
 
 
 /* Opens a file */

--- a/ext2/libext2.c
+++ b/ext2/libext2.c
@@ -25,20 +25,16 @@
 #include "libext2.h"
 
 
-int libext2_handler(void *fdata, msg_t *msg)
+static int libext2_create(void *info, oid_t *oid, const char *name, oid_t *dev, unsigned mode, int type, oid_t *res)
 {
-	ext2_t *fs = (ext2_t *)fdata;
+	ext2_t *fs = (ext2_t *)info;
 	ext2_obj_t *obj;
-	uint16_t mode;
-	oid_t dev;
-	unsigned int namelen;
+	oid_t devOther;
+	size_t namelen;
+	int ret;
+	dev->port = fs->port;
 
-	switch (msg->type) {
-	case mtCreate:
-		mode = (uint16_t)msg->i.create.mode;
-		msg->o.create.oid.port = fs->oid.port;
-
-		switch (msg->i.create.type) {
+	switch (type) {
 		case otDir:
 			mode |= S_IFDIR;
 			break;
@@ -55,128 +51,231 @@ int libext2_handler(void *fdata, msg_t *msg)
 		case otSymlink:
 			mode |= S_IFLNK;
 			break;
+	}
+
+	namelen = strlen(name);
+	if (namelen > UINT8_MAX) {
+		return -ENAMETOOLONG;
+	}
+
+	if (ext2_lookup(fs, oid->id, name, namelen, dev, &devOther) > 0) {
+		if ((obj = ext2_obj_get(fs, dev->id)) == NULL) {
+			return -EINVAL;
 		}
 
-		/* FIXME: casting namelen to (uint8_t) is not a good way to check for length constraints */
-		namelen = strlen(msg->i.data);
-		if (ext2_lookup(fs, msg->i.create.dir.id, msg->i.data, namelen, &msg->o.create.oid.id, &dev) > 0) {
-			if ((obj = ext2_obj_get(fs, msg->o.create.oid.id)) == NULL) {
-				msg->o.create.err = -EINVAL;
-				break;
-			}
+		mutexLock(obj->lock);
 
-			mutexLock(obj->lock);
+		if (S_ISCHR(obj->inode->mode) || S_ISBLK(obj->inode->mode)) {
+			if (!devOther.port && !devOther.id && (S_ISCHR(mode) || S_ISBLK(mode))) {
+				memcpy(&obj->dev, res, sizeof(oid_t));
+				obj->inode->mode = mode;
+				obj->flags |= OFLAG_DIRTY;
+				dev->id = obj->id;
+				ret = _ext2_obj_sync(fs, obj);
 
-			if (S_ISCHR(obj->inode->mode) || S_ISBLK(obj->inode->mode)) {
-				if (!dev.port && !dev.id && (S_ISCHR(mode) || S_ISBLK(mode))) {
-					memcpy(&obj->dev, &msg->i.create.dev, sizeof(oid_t));
-					obj->inode->mode = mode;
-					obj->flags |= OFLAG_DIRTY;
-					msg->o.create.oid.id = obj->id;
-					msg->o.create.err = _ext2_obj_sync(fs, obj);
-
-					mutexUnlock(obj->lock);
-					ext2_obj_put(fs, obj);
-					break;
-				}
-				else {
-					mutexUnlock(obj->lock);
-					ext2_obj_put(fs, obj);
-
-					if ((dev.port == fs->oid.port) && (dev.id == msg->o.create.oid.id)) {
-						if (ext2_unlink(fs, msg->i.create.dir.id, msg->i.data, namelen) < 0) {
-							msg->o.create.err = -EEXIST;
-							break;
-						}
-					}
-					else {
-						msg->o.create.err = -EEXIST;
-						break;
-					}
-				}
+				mutexUnlock(obj->lock);
+				ext2_obj_put(fs, obj);
+				return ret;
 			}
 			else {
 				mutexUnlock(obj->lock);
 				ext2_obj_put(fs, obj);
 
-				msg->o.create.err = -EEXIST;
-				break;
+				if ((devOther.port == fs->port) && (devOther.id == dev->id)) {
+					if (ext2_unlink(fs, oid->id, name, namelen) < 0) {
+						return -EEXIST;
+					}
+				}
+				else {
+					return -EEXIST;
+				}
 			}
 		}
-
-		msg->o.create.err = ext2_create(fs, msg->i.create.dir.id, msg->i.data, namelen, &msg->i.create.dev, mode, &msg->o.create.oid.id);
-
-		if (msg->o.create.err >= 0 && msg->i.create.type == otSymlink) {
-			const char *target = msg->i.data + namelen + 1;
-			int targetlen = strlen(target);
-			int ret;
-
-			/* not writing trailing '\0', readlink() does not append it */
-			ret = ext2_write(fs, msg->o.create.oid.id, 0, target, targetlen);
-			if (ret < 0) {
-				msg->o.create.err = ret;
-				ext2_destroy(fs, msg->o.create.oid.id);
-				msg->o.create.oid.id = 0;
-			}
+		else {
+			mutexUnlock(obj->lock);
+			ext2_obj_put(fs, obj);
+			return -EEXIST;
 		}
-		break;
+	}
 
-	case mtDestroy:
-		msg->o.io.err = ext2_destroy(fs, msg->i.destroy.oid.id);
-		break;
+	ret = ext2_create(fs, oid->id, name, namelen, res, mode, &dev->id);
 
-	case mtLookup:
-		msg->o.lookup.fil.port = fs->oid.port;
-		msg->o.lookup.err = ext2_lookup(fs, msg->i.lookup.dir.id, msg->i.data, (uint8_t)strlen(msg->i.data), &msg->o.lookup.fil.id, &msg->o.lookup.dev);
-		break;
+	if (ret >= 0 && type == otSymlink) {
+		const char *target = name + namelen + 1;
+		size_t targetlen = strlen(target);
+		int retWrite;
 
-	case mtOpen:
-		ext2_open(fs, msg->i.openclose.oid.id);
-		break;
+		/* not writing trailing '\0', readlink() does not append it */
+		retWrite = ext2_write(fs, dev->id, 0, target, targetlen);
+		if (retWrite < 0) {
+			ret = retWrite;
+			ext2_destroy(fs, dev->id);
+			dev->id = 0;
+		}
+	}
 
-	case mtClose:
-		ext2_close(fs, msg->i.openclose.oid.id);
-		break;
+	return ret;
+}
 
-	case mtRead:
-		msg->o.io.err = ext2_read(fs, msg->i.io.oid.id, msg->i.io.offs, msg->o.data, msg->o.size);
-		break;
 
-	case mtReaddir:
-		msg->o.io.err = ext2_read(fs, msg->i.readdir.dir.id, msg->i.readdir.offs, msg->o.data, msg->o.size);
-		break;
+static int libext2_open(void *info, oid_t *oid)
+{
+	return ext2_open((ext2_t *)info, oid->id);
+}
 
-	case mtWrite:
-		msg->o.io.err = ext2_write(fs, msg->i.io.oid.id, msg->i.io.offs, msg->i.data, msg->i.size);
-		break;
 
-	case mtTruncate:
-		msg->o.io.err = ext2_truncate(fs, msg->i.io.oid.id, msg->i.io.len);
-		break;
+static int libext2_close(void *info, oid_t *oid)
+{
+	return ext2_close((ext2_t *)info, oid->id);
+}
 
-	case mtDevCtl:
-		msg->o.io.err = -EINVAL;
-		break;
 
-	case mtGetAttr:
-		msg->o.attr.err = ext2_getattr(fs, msg->i.attr.oid.id, msg->i.attr.type, &msg->o.attr.val);
-		break;
+static ssize_t libext2_read(void *info, oid_t *oid, offs_t offs, void *data, size_t len)
+{
+	return ext2_read((ext2_t *)info, oid->id, offs, data, len);
+}
 
-	case mtSetAttr:
-		msg->o.attr.err = ext2_setattr(fs, msg->i.attr.oid.id, msg->i.attr.type, msg->i.attr.val);
-		break;
 
-	case mtLink:
-		msg->o.io.err = ext2_link(fs, msg->i.ln.dir.id, msg->i.data, (uint8_t)strlen(msg->i.data), msg->i.ln.oid.id);
-		break;
+static ssize_t libext2_write(void *info, oid_t *oid, offs_t offs, const void *data, size_t len)
+{
+	return ext2_write((ext2_t *)info, oid->id, offs, data, len);
+}
 
-	case mtUnlink:
-		msg->o.io.err = ext2_unlink(fs, msg->i.ln.dir.id, msg->i.data, (uint8_t)strlen(msg->i.data));
-		break;
 
-	case mtStat:
-		msg->o.io.err = ext2_statfs(fs, msg->o.data, msg->o.size);
-		break;
+static int libext2_setattr(void *info, oid_t *oid, int type, long long attr, void *data, size_t len)
+{
+	return ext2_setattr((ext2_t *)info, oid->id, type, attr);
+}
+
+
+static int libext2_getattr(void *info, oid_t *oid, int type, long long *attr)
+{
+	return ext2_getattr((ext2_t *)info, oid->id, type, attr);
+}
+
+
+static int libext2_truncate(void *info, oid_t *oid, size_t size)
+{
+	return ext2_truncate((ext2_t *)info, oid->id, size);
+}
+
+
+static int libext2_destroy(void *info, oid_t *oid)
+{
+	return ext2_destroy((ext2_t *)info, oid->id);
+}
+
+
+static int libext2_lookup(void *info, oid_t *oid, const char *name, oid_t *res, oid_t *dev, char *lnk, int lnksz)
+{
+	size_t namelen = strlen(name);
+	if (namelen > UINT8_MAX) {
+		return -ENAMETOOLONG;
+	}
+
+	return ext2_lookup((ext2_t *)info, oid->id, name, namelen, res, dev);
+}
+
+
+static int libext2_link(void *info, oid_t *oid, const char *name, oid_t *res)
+{
+	size_t namelen = strlen(name);
+	if (namelen > UINT8_MAX) {
+		return -ENAMETOOLONG;
+	}
+
+	return ext2_link((ext2_t *)info, oid->id, name, namelen, res->id);
+}
+
+
+static int libext2_unlink(void *info, oid_t *oid, const char *name)
+{
+	size_t namelen = strlen(name);
+	if (namelen > UINT8_MAX) {
+		return -ENAMETOOLONG;
+	}
+
+	return ext2_unlink((ext2_t *)info, oid->id, name, namelen);
+}
+
+
+static int libext2_readdir(void *info, oid_t *oid, offs_t offs, struct dirent *dent, size_t size)
+{
+	return ext2_read((ext2_t *)info, oid->id, offs, (char *)dent, size);
+}
+
+
+static int libext2_statfs(void *info, void *buf, size_t len)
+{
+	return ext2_statfs((ext2_t *)info, buf, len);
+}
+
+
+int libext2_handler(void *fdata, msg_t *msg)
+{
+	switch (msg->type) {
+		case mtCreate:
+			msg->o.create.err = libext2_create(fdata, &msg->i.create.dir, msg->i.data, &msg->o.create.oid, msg->i.create.mode, msg->i.create.type, &msg->i.create.dev);
+			break;
+
+		case mtDestroy:
+			msg->o.io.err = libext2_destroy(fdata, &msg->i.destroy.oid);
+			break;
+
+		case mtLookup:
+			msg->o.lookup.err = libext2_lookup(fdata, &msg->i.lookup.dir, msg->i.data, &msg->o.lookup.fil, &msg->o.lookup.dev, msg->o.data, msg->o.size);
+			break;
+
+		case mtOpen:
+			msg->o.io.err = libext2_open(fdata, &msg->i.openclose.oid);
+			break;
+
+		case mtClose:
+			msg->o.io.err = libext2_close(fdata, &msg->i.openclose.oid);
+			break;
+
+		case mtRead:
+			msg->o.io.err = libext2_read(fdata, &msg->i.io.oid, msg->i.io.offs, msg->o.data, msg->o.size);
+			break;
+
+		case mtReaddir:
+			msg->o.io.err = libext2_readdir(fdata, &msg->i.readdir.dir, msg->i.readdir.offs, msg->o.data, msg->o.size);
+			break;
+
+		case mtWrite:
+			msg->o.io.err = libext2_write(fdata, &msg->i.io.oid, msg->i.io.offs, msg->i.data, msg->i.size);
+			break;
+
+		case mtTruncate:
+			msg->o.io.err = libext2_truncate(fdata, &msg->i.io.oid, msg->i.io.len);
+			break;
+
+		case mtDevCtl:
+			msg->o.io.err = -EINVAL;
+			break;
+
+		case mtGetAttr:
+			msg->o.attr.err = libext2_getattr(fdata, &msg->i.attr.oid, msg->i.attr.type, &msg->o.attr.val);
+			break;
+
+		case mtSetAttr:
+			msg->o.attr.err = libext2_setattr(fdata, &msg->i.attr.oid, msg->i.attr.type, msg->i.attr.val, msg->i.data, msg->i.size);
+			break;
+
+		case mtLink:
+			msg->o.io.err = libext2_link(fdata, &msg->i.ln.dir, msg->i.data, &msg->i.ln.oid);
+			break;
+
+		case mtUnlink:
+			msg->o.io.err = libext2_unlink(fdata, &msg->i.ln.dir, msg->i.data);
+			break;
+
+		case mtStat:
+			msg->o.io.err = libext2_statfs(fdata, msg->o.data, msg->o.size);
+			break;
+
+		default:
+			break;
 	}
 
 	return EOK;
@@ -205,9 +304,11 @@ int libext2_mount(oid_t *oid, unsigned int sectorsz, dev_read read, dev_write wr
 		return -ENOMEM;
 
 	fs->sectorsz = sectorsz;
-	fs->read = read;
-	fs->write = write;
-	memcpy(&fs->oid, oid, sizeof(oid_t));
+	fs->strg = NULL;
+	fs->legacy.devId = oid->id;
+	fs->legacy.read = read;
+	fs->legacy.write = write;
+	fs->port = oid->port;
 
 	if ((err = ext2_sb_init(fs)) < 0) {
 		free(fs);
@@ -236,4 +337,97 @@ int libext2_mount(oid_t *oid, unsigned int sectorsz, dev_read read, dev_write wr
 	}
 
 	return ROOT_INO;
+}
+
+
+const static storage_fsops_t fsOps = {
+	.open = libext2_open,
+	.close = libext2_close,
+	.read = libext2_read,
+	.write = libext2_write,
+	.setattr = libext2_setattr,
+	.getattr = libext2_getattr,
+	.truncate = libext2_truncate,
+	.devctl = NULL,
+	.create = libext2_create,
+	.destroy = libext2_destroy,
+	.lookup = libext2_lookup,
+	.link = libext2_link,
+	.unlink = libext2_unlink,
+	.readdir = libext2_readdir,
+	.statfs = libext2_statfs,
+	.sync = NULL
+};
+
+
+int libext2_storage_umount(storage_fs_t *strg_fs)
+{
+	ext2_t *fs = (ext2_t *)strg_fs->info;
+	ext2_objs_destroy(fs);
+	ext2_gdt_destroy(fs);
+	ext2_sb_destroy(fs);
+	free(fs);
+
+	return EOK;
+}
+
+
+int libext2_storage_mount(storage_t *strg, storage_fs_t *fs, const char *data, unsigned long mode, oid_t *root)
+{
+	ext2_t *info;
+	int err;
+
+	if (strg == NULL ||
+		strg->dev == NULL ||
+		strg->dev->blk == NULL ||
+		strg->dev->blk->ops == NULL ||
+		strg->dev->blk->ops->read == NULL ||
+		strg->dev->blk->ops->write == NULL) {
+		return -ENOSYS;
+	}
+
+	info = (ext2_t *)malloc(sizeof(ext2_t));
+	if (info == NULL) {
+		return -ENOMEM;
+	}
+
+	/* TODO: this needs to be configurable to be compatible with pc-ata */
+	info->sectorsz = 512;
+	info->strg = strg;
+	info->legacy.devId = 0;
+	info->legacy.read = NULL;
+	info->legacy.write = NULL;
+	info->port = root->port;
+	root->id = ROOT_INO;
+
+	fs->info = info;
+	fs->ops = &fsOps;
+
+	if ((err = ext2_sb_init(info)) < 0) {
+		free(info);
+		return err;
+	}
+
+	if ((err = ext2_gdt_init(info)) < 0) {
+		ext2_sb_destroy(info);
+		free(info);
+		return err;
+	}
+
+	if ((err = ext2_objs_init(info)) < 0) {
+		ext2_gdt_destroy(info);
+		ext2_sb_destroy(info);
+		free(info);
+		return err;
+	}
+
+	if ((info->root = ext2_obj_get(info, ROOT_INO)) == NULL) {
+		ext2_objs_destroy(info);
+		ext2_gdt_destroy(info);
+		ext2_sb_destroy(info);
+		free(info);
+		return -ENOENT;
+	}
+
+	return EOK;
 }

--- a/ext2/libext2.h
+++ b/ext2/libext2.h
@@ -21,6 +21,8 @@
 #include <sys/msg.h>
 #include <sys/types.h>
 
+#include <storage/storage.h>
+
 
 #define LIBEXT2_NAME    "ext2"
 #define LIBEXT2_TYPE    0x83
@@ -39,6 +41,13 @@ extern int libext2_unmount(void *fdata);
 
 /* Mounts filesystem */
 extern int libext2_mount(oid_t *dev, unsigned int sectorsz, ssize_t (*read)(id_t, offs_t, char *, size_t), ssize_t (*write)(id_t, offs_t, const char *, size_t), void **fdata);
+
+/* Unmount filesystem callback for libstorage */
+extern int libext2_storage_umount(storage_fs_t *fs);
+
+
+/* Mount filesystem callback for libstorage */
+extern int libext2_storage_mount(storage_t *strg, storage_fs_t *fs, const char *data, unsigned long mode, oid_t *root);
 
 
 #endif


### PR DESCRIPTION
Modified `libext2` to make it compatible with `libstorage`. This will make the filesystem driver compatible with storage device drivers based on `libstorage`.

## Description
Message handling performed by the `libext2_handler` was split into separate functions that are compatible with the `libstorage` API for file systems.

Compatibility with `pc-ata` storage driver (that uses the current API for handling ext2 filesystems) was not affected.

Additionally, length checks on file names were added (previously name lengths could cause integer overflow).

## Motivation and Context
ext2 filesystem would be useful for data exchange using [SD cards](https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/433) as ext2 can be easily mounted on many host PC operating systems.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu, armv7a9-zynq7000-zturn

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
