### PR TITLE
ext2: Fix ext2_obj_get reval check in ext2_getattr

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -274,77 +274,83 @@ int ext2_truncate(ext2_t *fs, id_t id, size_t size)
 
 int ext2_getattr(ext2_t *fs, id_t id, int type, long long *attr)
 {
-	ext2_obj_t *obj;
 	int ret = EOK;
+	ext2_obj_t *obj = ext2_obj_get(fs, id);
 
-	if ((obj = ext2_obj_get(fs, id)) < 0)
+	if (obj == NULL) {
 		return -EINVAL;
+	}
 
 	mutexLock(obj->lock);
 
 	switch(type) {
-	case atMode:
-		*attr = obj->inode->mode;
-		break;
+		case atMode:
+			*attr = obj->inode->mode;
+			break;
 
-	case atUid:
-		*attr = obj->inode->uid;
-		break;
+		case atUid:
+			*attr = obj->inode->uid;
+			break;
 
-	case atGid:
-		*attr = obj->inode->gid;
-		break;
+		case atGid:
+			*attr = obj->inode->gid;
+			break;
 
-	case atSize:
-		*attr = obj->inode->size;
-		break;
+		case atSize:
+			*attr = obj->inode->size;
+			break;
 
-	case atBlocks:
-		*attr = obj->inode->blocks;
-		break;
+		case atBlocks:
+			*attr = obj->inode->blocks;
+			break;
 
-	case atIOBlock:
-		/* TODO: determine optimal I/O block size */
-		/* fs->blocksz seems reasonable for now */
-		*attr = fs->blocksz;
-		break;
+		case atIOBlock:
+			/* TODO: determine optimal I/O block size */
+			/* fs->blocksz seems reasonable for now */
+			*attr = fs->blocksz;
+			break;
 
-	case atType:
-		if (S_ISDIR(obj->inode->mode))
-			*attr = otDir;
-		else if (S_ISREG(obj->inode->mode))
-			*attr = otFile;
-		else if (S_ISCHR(obj->inode->mode) || S_ISBLK(obj->inode->mode) || S_ISFIFO(obj->inode->mode))
-			*attr = otDev;
-		else if (S_ISLNK(obj->inode->mode))
-			*attr = otSymlink;
-		else
-			*attr = otUnknown;
-		break;
+		case atType:
+			if (S_ISDIR(obj->inode->mode)) {
+				*attr = otDir;
+			}
+			else if (S_ISREG(obj->inode->mode)) {
+				*attr = otFile;
+			}
+			else if (S_ISCHR(obj->inode->mode) || S_ISBLK(obj->inode->mode) || S_ISFIFO(obj->inode->mode)) {
+				*attr = otDev;
+			}
+			else if (S_ISLNK(obj->inode->mode)) {
+				*attr = otSymlink;
+			}
+			else {
+				*attr = otUnknown;
+			}
+			break;
 
-	case atCTime:
-		*attr = obj->inode->ctime;
-		break;
+		case atCTime:
+			*attr = obj->inode->ctime;
+			break;
 
-	case atATime:
-		*attr = obj->inode->atime;
-		break;
+		case atATime:
+			*attr = obj->inode->atime;
+			break;
 
-	case atMTime:
-		*attr = obj->inode->mtime;
-		break;
+		case atMTime:
+			*attr = obj->inode->mtime;
+			break;
 
-	case atLinks:
-		*attr = obj->inode->links;
-		break;
+		case atLinks:
+			*attr = obj->inode->links;
+			break;
 
-	case atPollStatus:
-		*attr = POLLIN | POLLRDNORM | POLLOUT | POLLWRNORM;
-		break;
+		case atPollStatus:
+			*attr = POLLIN | POLLRDNORM | POLLOUT | POLLWRNORM;
+			break;
 
-	default:
-		ret = -EINVAL;
-		break;
+		default:
+			ret = -EINVAL;
+			break;
 	}
 
 	mutexUnlock(obj->lock);


### PR DESCRIPTION
DONE: RTOS-669

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/910

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
