### PR TITLE
ext2: Add ability to mount devices and filesystems

### DIFF
--- a/ext2/dir.c
+++ b/ext2/dir.c
@@ -176,9 +176,6 @@ int _ext2_dir_read(ext2_t *fs, ext2_obj_t *dir, offs_t offs, struct dirent *res,
 	res->d_name[entry->len] = '\0';
 	free(entry);
 
-	if ((dir->flags & OFLAG_MOUNTPOINT) && !strncmp(res->d_name, "..", 2))
-		res->d_ino = (ino_t)dir->mnt.id;
-
 	dir->inode->atime = time(NULL);
 
 	return res->d_reclen;
@@ -251,6 +248,10 @@ int _ext2_dir_add(ext2_t *fs, ext2_obj_t *dir, const char *name, size_t len, uin
 		entry->type = DIRENT_CHRDEV;
 	else if (S_ISBLK(mode))
 		entry->type = DIRENT_BLKDEV;
+	else if (S_ISFIFO(mode))
+		entry->type = DIRENT_FIFO;
+	else if (S_ISSOCK(mode))
+		entry->type = DIRENT_SOCK;
 	else if (S_ISREG(mode))
 		entry->type = DIRENT_FILE;
 	else

--- a/ext2/dir.h
+++ b/ext2/dir.h
@@ -17,6 +17,7 @@
 #define _DIR_H_
 
 #include <dirent.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include <sys/types.h>
@@ -51,7 +52,7 @@ extern int _ext2_dir_empty(ext2_t *fs, ext2_obj_t *dir);
 
 
 /* Searches directory for a given file name (requires object to be locked) */
-extern int _ext2_dir_search(ext2_t *fs, ext2_obj_t *dir, const char *name, uint8_t len, id_t *res);
+extern int _ext2_dir_search(ext2_t *fs, ext2_obj_t *dir, const char *name, size_t len, id_t *res);
 
 
 /* Reads directory entry (requires object to be locked) */
@@ -59,11 +60,11 @@ extern int _ext2_dir_read(ext2_t *fs, ext2_obj_t *dir, offs_t offs, struct diren
 
 
 /* Adds directory entry (requires object to be locked) */
-extern int _ext2_dir_add(ext2_t *fs, ext2_obj_t *dir, const char *name, uint8_t len, uint16_t mode, uint32_t ino);
+extern int _ext2_dir_add(ext2_t *fs, ext2_obj_t *dir, const char *name, size_t len, uint16_t mode, uint32_t ino);
 
 
 /* Removes directory entry (requires object to be locked) */
-extern int _ext2_dir_remove(ext2_t *fs, ext2_obj_t *dir, const char *name, uint8_t len);
+extern int _ext2_dir_remove(ext2_t *fs, ext2_obj_t *dir, const char *name, size_t len);
 
 
 #endif

--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -28,7 +28,7 @@
 #include "file.h"
 
 
-int ext2_create(ext2_t *fs, id_t id, const char *name, uint8_t len, oid_t *dev, uint16_t mode, id_t *res)
+int ext2_create(ext2_t *fs, id_t id, const char *name, size_t len, oid_t *dev, uint16_t mode, id_t *res)
 {
 	ext2_obj_t *obj;
 	int err;
@@ -74,10 +74,10 @@ int ext2_destroy(ext2_t *fs, id_t id)
 }
 
 
-int ext2_lookup(ext2_t *fs, id_t id, const char *name, uint8_t len, oid_t *res, oid_t *dev)
+int ext2_lookup(ext2_t *fs, id_t id, const char *name, size_t len, oid_t *res, oid_t *dev)
 {
 	ext2_obj_t *dir, *obj = NULL;
-	uint8_t i, j;
+	size_t i, j;
 	int err;
 
 	res->port = fs->port;
@@ -424,7 +424,7 @@ int ext2_setattr(ext2_t *fs, id_t id, int type, long long attr)
 }
 
 
-int ext2_link(ext2_t *fs, id_t id, const char *name, uint8_t len, id_t lid)
+int ext2_link(ext2_t *fs, id_t id, const char *name, size_t len, id_t lid)
 {
 	ext2_obj_t *dir, *obj;
 	id_t res;
@@ -498,7 +498,7 @@ int ext2_link(ext2_t *fs, id_t id, const char *name, uint8_t len, id_t lid)
 }
 
 
-int ext2_unlink(ext2_t *fs, id_t id, const char *name, uint8_t len)
+int ext2_unlink(ext2_t *fs, id_t id, const char *name, size_t len)
 {
 	ext2_obj_t *dir, *obj;
 	id_t res;

--- a/ext2/ext2.h
+++ b/ext2/ext2.h
@@ -72,7 +72,7 @@ typedef struct {
 
 
 /* Creates a file */
-extern int ext2_create(ext2_t *fs, id_t id, const char *name, uint8_t len, oid_t *dev, uint16_t mode, id_t *res);
+extern int ext2_create(ext2_t *fs, id_t id, const char *name, size_t len, oid_t *dev, uint16_t mode, id_t *res);
 
 
 /* Destroys a file */
@@ -80,7 +80,7 @@ extern int ext2_destroy(ext2_t *fs, id_t id);
 
 
 /* Lookups a file */
-extern int ext2_lookup(ext2_t *fs, id_t id, const char *name, uint8_t len, oid_t *res, oid_t *dev);
+extern int ext2_lookup(ext2_t *fs, id_t id, const char *name, size_t len, oid_t *res, oid_t *dev);
 
 
 /* Opens a file */
@@ -112,11 +112,11 @@ extern int ext2_setattr(ext2_t *fs, id_t id, int type, long long attr);
 
 
 /* Adds a link */
-extern int ext2_link(ext2_t *fs, id_t id, const char *name, uint8_t len, id_t lid);
+extern int ext2_link(ext2_t *fs, id_t id, const char *name, size_t len, id_t lid);
 
 
 /* Removes a link */
-extern int ext2_unlink(ext2_t *fs, id_t id, const char *name, uint8_t len);
+extern int ext2_unlink(ext2_t *fs, id_t id, const char *name, size_t len);
 
 
 /* Retrieves filesystem statistics */

--- a/ext2/ext2.h
+++ b/ext2/ext2.h
@@ -30,6 +30,9 @@
 #define MAX_OBJECTS 512 /* Max number of filesystem objects in use */
 
 
+#define EXT2_ISDEV(x) (S_ISCHR(x) || S_ISBLK(x) || S_ISFIFO(x) || S_ISSOCK(x))
+
+
 /* Filesystem common data types forward declaration */
 typedef struct _ext2_sb_t ext2_sb_t;     /* SuperBlock */
 typedef struct _ext2_gd_t ext2_gd_t;     /* Group Descriptor*/
@@ -108,7 +111,7 @@ extern int ext2_getattr(ext2_t *fs, id_t id, int type, long long *attr);
 
 
 /* Sets file attributes */
-extern int ext2_setattr(ext2_t *fs, id_t id, int type, long long attr);
+extern int ext2_setattr(ext2_t *fs, id_t id, int type, long long attr, void *data, size_t len);
 
 
 /* Adds a link */

--- a/ext2/libext2.c
+++ b/ext2/libext2.c
@@ -30,7 +30,6 @@ static int libext2_create(void *info, oid_t *oid, const char *name, oid_t *dev, 
 	ext2_t *fs = (ext2_t *)info;
 	ext2_obj_t *obj;
 	oid_t devOther;
-	size_t namelen;
 	int ret;
 	dev->port = fs->port;
 
@@ -53,10 +52,7 @@ static int libext2_create(void *info, oid_t *oid, const char *name, oid_t *dev, 
 			break;
 	}
 
-	namelen = strlen(name);
-	if (namelen > UINT8_MAX) {
-		return -ENAMETOOLONG;
-	}
+	size_t namelen = strlen(name);
 
 	if (ext2_lookup(fs, oid->id, name, namelen, dev, &devOther) > 0) {
 		if ((obj = ext2_obj_get(fs, dev->id)) == NULL) {
@@ -168,34 +164,19 @@ static int libext2_destroy(void *info, oid_t *oid)
 
 static int libext2_lookup(void *info, oid_t *oid, const char *name, oid_t *res, oid_t *dev, char *lnk, int lnksz)
 {
-	size_t namelen = strlen(name);
-	if (namelen > UINT8_MAX) {
-		return -ENAMETOOLONG;
-	}
-
-	return ext2_lookup((ext2_t *)info, oid->id, name, namelen, res, dev);
+	return ext2_lookup((ext2_t *)info, oid->id, name, strlen(name), res, dev);
 }
 
 
 static int libext2_link(void *info, oid_t *oid, const char *name, oid_t *res)
 {
-	size_t namelen = strlen(name);
-	if (namelen > UINT8_MAX) {
-		return -ENAMETOOLONG;
-	}
-
-	return ext2_link((ext2_t *)info, oid->id, name, namelen, res->id);
+	return ext2_link((ext2_t *)info, oid->id, name, strlen(name), res->id);
 }
 
 
 static int libext2_unlink(void *info, oid_t *oid, const char *name)
 {
-	size_t namelen = strlen(name);
-	if (namelen > UINT8_MAX) {
-		return -ENAMETOOLONG;
-	}
-
-	return ext2_unlink((ext2_t *)info, oid->id, name, namelen);
+	return ext2_unlink((ext2_t *)info, oid->id, name, strlen(name));
 }
 
 

--- a/ext2/obj.h
+++ b/ext2/obj.h
@@ -27,25 +27,23 @@
 
 /* Object flags */
 enum {
-	OFLAG_DIRTY      = 0x01,
+	OFLAG_DIRTY = 0x01,
 	OFLAG_MOUNTPOINT = 0x02,
-	OFLAG_MOUNT      = 0x04
 };
 
+#define EXT2_IS_DIRTY(obj)      (((obj)->flags & OFLAG_DIRTY) != 0)
+#define EXT2_IS_MOUNTPOINT(obj) (((obj)->flags & OFLAG_MOUNTPOINT) != 0)
 
 struct _ext2_obj_t {
 	id_t id;                 /* Object ID, same as underlying inode number */
 	rbnode_t node;           /* RBTree node */
 
 	/* Object data */
-	union {
-		struct {
-			uint32_t bno;
-			uint32_t *data;
-		} ind[3];            /* Indirect blocks */
-		oid_t mnt;           /* Mounted filesystem */
-		oid_t dev;           /* Device */
-	};
+	struct {
+		uint32_t bno;
+		uint32_t *data;
+	} ind[3];                /* Indirect blocks */
+	oid_t dev;               /* Device */
 	uint32_t refs;           /* Reference counter */
 	uint8_t flags;           /* Object flags */
 	ext2_inode_t *inode;     /* Underlying inode */


### PR DESCRIPTION
Added the ability to mount a different filesystem within an ext2 filesystem.

## Description
Now another filesystem can be mounted using a directory within ext2 as the mountpoint. 

Additionally, the ext2 filesystem driver had a path length limit of 255 characters. This limitation has been removed and now paths of any length can be looked up within ext2. Single file names are still limited to 255 characters, as this is a file system limitation.

This also fixes issue https://github.com/phoenix-rtos/phoenix-rtos-project/issues/749 (on ext2 only).

## Motivation and Context
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/114

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu, armv7a9-zynq7000-zturn

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
