### PR TITLE
use off_t instead of offs_t

### DIFF
--- a/dummyfs/dummyfs.c
+++ b/dummyfs/dummyfs.c
@@ -632,7 +632,7 @@ int dummyfs_unlink(void *ctx, oid_t *dir, const char *name)
 }
 
 
-static int _dummyfs_writeObject(dummyfs_t *fs, dummyfs_object_t *o, offs_t offs, const char *buff, size_t len);
+static int _dummyfs_writeObject(dummyfs_t *fs, dummyfs_object_t *o, off_t offs, const char *buff, size_t len);
 
 
 static int _dummyfs_create(dummyfs_t *fs, oid_t *dir, const char *name, oid_t *oid, unsigned mode, int type, oid_t *dev)
@@ -758,7 +758,7 @@ int dummyfs_destroy(void *ctx, oid_t *oid)
 }
 
 
-int dummyfs_readdir(void *ctx, oid_t *dir, offs_t offs, struct dirent *dent, unsigned int size)
+int dummyfs_readdir(void *ctx, oid_t *dir, off_t offs, struct dirent *dent, unsigned int size)
 {
 	TRACE();
 	dummyfs_t *fs = (dummyfs_t *)ctx;
@@ -876,7 +876,7 @@ int dummyfs_close(void *ctx, oid_t *oid)
 }
 
 
-int dummyfs_read(void *ctx, oid_t *oid, offs_t offs, char *buff, size_t len)
+int dummyfs_read(void *ctx, oid_t *oid, off_t offs, char *buff, size_t len)
 {
 	TRACE();
 	dummyfs_t *fs = (dummyfs_t *)ctx;
@@ -903,7 +903,7 @@ int dummyfs_read(void *ctx, oid_t *oid, offs_t offs, char *buff, size_t len)
 		return -EINVAL;
 	}
 
-	if (((offs_t)o->size <= offs) || (len == 0)) {
+	if (((off_t)o->size <= offs) || (len == 0)) {
 		dummyfs_object_put(fs, o);
 		mutexUnlock(fs->mutex);
 		return 0;
@@ -948,7 +948,7 @@ int dummyfs_read(void *ctx, oid_t *oid, offs_t offs, char *buff, size_t len)
 }
 
 
-static int _dummyfs_writeObject(dummyfs_t *fs, dummyfs_object_t *o, offs_t offs, const char *buff, size_t len)
+static int _dummyfs_writeObject(dummyfs_t *fs, dummyfs_object_t *o, off_t offs, const char *buff, size_t len)
 {
 	TRACE();
 	size_t cnt = 0;
@@ -1028,7 +1028,7 @@ static int _dummyfs_writeObject(dummyfs_t *fs, dummyfs_object_t *o, offs_t offs,
 }
 
 
-int dummyfs_write(void *ctx, oid_t *oid, offs_t offs, const char *buff, size_t len)
+int dummyfs_write(void *ctx, oid_t *oid, off_t offs, const char *buff, size_t len)
 {
 	TRACE();
 	dummyfs_t *fs = (dummyfs_t *)ctx;

--- a/dummyfs/dummyfs.h
+++ b/dummyfs/dummyfs.h
@@ -21,10 +21,10 @@ int dummyfs_open(void *ctx, oid_t *oid);
 int dummyfs_close(void *ctx, oid_t *oid);
 
 
-int dummyfs_read(void *ctx, oid_t *oid, offs_t offs, char *buff, size_t len);
+int dummyfs_read(void *ctx, oid_t *oid, off_t offs, char *buff, size_t len);
 
 
-int dummyfs_write(void *ctx, oid_t *oid, offs_t offs, const char *buff, size_t len);
+int dummyfs_write(void *ctx, oid_t *oid, off_t offs, const char *buff, size_t len);
 
 
 int dummyfs_truncate(void *ctx, oid_t *oid, size_t size);
@@ -51,7 +51,7 @@ int dummyfs_link(void *ctx, oid_t *dir, const char *name, oid_t *oid);
 int dummyfs_unlink(void *ctx, oid_t *dir, const char *name);
 
 
-int dummyfs_readdir(void *ctx, oid_t *dir, offs_t offs, struct dirent *dent, unsigned int size);
+int dummyfs_readdir(void *ctx, oid_t *dir, off_t offs, struct dirent *dent, unsigned int size);
 
 
 int dummyfs_createMapped(void *ctx, oid_t *dir, const char *name, void *addr, size_t size, oid_t *oid);

--- a/ext2/dir.c
+++ b/ext2/dir.c
@@ -115,7 +115,7 @@ int _ext2_dir_search(ext2_t *fs, ext2_obj_t *dir, const char *name, size_t len, 
 }
 
 
-int _ext2_dir_read(ext2_t *fs, ext2_obj_t *dir, offs_t offs, struct dirent *res, size_t len)
+int _ext2_dir_read(ext2_t *fs, ext2_obj_t *dir, off_t offs, struct dirent *res, size_t len)
 {
 	ext2_dirent_t *entry;
 	ssize_t ret;

--- a/ext2/dir.h
+++ b/ext2/dir.h
@@ -56,7 +56,7 @@ extern int _ext2_dir_search(ext2_t *fs, ext2_obj_t *dir, const char *name, size_
 
 
 /* Reads directory entry (requires object to be locked) */
-extern int _ext2_dir_read(ext2_t *fs, ext2_obj_t *dir, offs_t offs, struct dirent *res, size_t len);
+extern int _ext2_dir_read(ext2_t *fs, ext2_obj_t *dir, off_t offs, struct dirent *res, size_t len);
 
 
 /* Adds directory entry (requires object to be locked) */

--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -183,7 +183,7 @@ int ext2_close(ext2_t *fs, id_t id)
 }
 
 
-ssize_t ext2_read(ext2_t *fs, id_t id, offs_t offs, char *buff, size_t len)
+ssize_t ext2_read(ext2_t *fs, id_t id, off_t offs, char *buff, size_t len)
 {
 	ext2_obj_t *obj;
 	ssize_t ret;
@@ -215,7 +215,7 @@ ssize_t ext2_read(ext2_t *fs, id_t id, offs_t offs, char *buff, size_t len)
 }
 
 
-ssize_t ext2_write(ext2_t *fs, id_t id, offs_t offs, const char *buff, size_t len)
+ssize_t ext2_write(ext2_t *fs, id_t id, off_t offs, const char *buff, size_t len)
 {
 	ext2_obj_t *obj;
 	ssize_t ret;

--- a/ext2/ext2.h
+++ b/ext2/ext2.h
@@ -41,8 +41,8 @@ typedef struct _ext2_objs_t ext2_objs_t; /* Filesystem objects */
 
 
 /* Device access callbacks */
-typedef ssize_t (*dev_read)(id_t, offs_t, char *, size_t);
-typedef ssize_t (*dev_write)(id_t, offs_t, const char *, size_t);
+typedef ssize_t (*dev_read)(id_t, off_t, char *, size_t);
+typedef ssize_t (*dev_write)(id_t, off_t, const char *, size_t);
 
 
 typedef struct {
@@ -95,11 +95,11 @@ extern int ext2_close(ext2_t *fs, id_t id);
 
 
 /* Reads from a file */
-extern ssize_t ext2_read(ext2_t *fs, id_t id, offs_t offs, char *buff, size_t len);
+extern ssize_t ext2_read(ext2_t *fs, id_t id, off_t offs, char *buff, size_t len);
 
 
 /* Writes to a file */
-extern ssize_t ext2_write(ext2_t *fs, id_t id, offs_t offs, const char *buff, size_t len);
+extern ssize_t ext2_write(ext2_t *fs, id_t id, off_t offs, const char *buff, size_t len);
 
 
 /* Truncates a file */

--- a/ext2/file.c
+++ b/ext2/file.c
@@ -22,7 +22,7 @@
 #include "file.h"
 
 
-ssize_t _ext2_file_read(ext2_t *fs, ext2_obj_t *obj, offs_t offs, char *buff, size_t len)
+ssize_t _ext2_file_read(ext2_t *fs, ext2_obj_t *obj, off_t offs, char *buff, size_t len)
 {
 	uint32_t block = offs / fs->blocksz;
 	size_t l = 0;
@@ -79,7 +79,7 @@ ssize_t _ext2_file_read(ext2_t *fs, ext2_obj_t *obj, offs_t offs, char *buff, si
 }
 
 
-ssize_t _ext2_file_write(ext2_t *fs, ext2_obj_t *obj, offs_t offs, const char *buff, size_t len)
+ssize_t _ext2_file_write(ext2_t *fs, ext2_obj_t *obj, off_t offs, const char *buff, size_t len)
 {
 	uint32_t block = offs / fs->blocksz;
 	size_t l = 0;

--- a/ext2/file.h
+++ b/ext2/file.h
@@ -24,11 +24,11 @@
 
 
 /* Reads a file (requires object to be locked) */
-extern ssize_t _ext2_file_read(ext2_t *fs, ext2_obj_t *obj, offs_t offs, char *buff, size_t len);
+extern ssize_t _ext2_file_read(ext2_t *fs, ext2_obj_t *obj, off_t offs, char *buff, size_t len);
 
 
 /* Writes a file (requires object to be locked) */
-extern ssize_t _ext2_file_write(ext2_t *fs, ext2_obj_t *obj, offs_t offs, const char *buff, size_t len);
+extern ssize_t _ext2_file_write(ext2_t *fs, ext2_obj_t *obj, off_t offs, const char *buff, size_t len);
 
 
 /* Truncates a file (requires object to be locked) */

--- a/ext2/libext2.c
+++ b/ext2/libext2.c
@@ -135,13 +135,13 @@ static int libext2_close(void *info, oid_t *oid)
 }
 
 
-static ssize_t libext2_read(void *info, oid_t *oid, offs_t offs, void *data, size_t len)
+static ssize_t libext2_read(void *info, oid_t *oid, off_t offs, void *data, size_t len)
 {
 	return ext2_read((ext2_t *)info, oid->id, offs, data, len);
 }
 
 
-static ssize_t libext2_write(void *info, oid_t *oid, offs_t offs, const void *data, size_t len)
+static ssize_t libext2_write(void *info, oid_t *oid, off_t offs, const void *data, size_t len)
 {
 	return ext2_write((ext2_t *)info, oid->id, offs, data, len);
 }
@@ -189,7 +189,7 @@ static int libext2_unlink(void *info, oid_t *oid, const char *name)
 }
 
 
-static int libext2_readdir(void *info, oid_t *oid, offs_t offs, struct dirent *dent, size_t size)
+static int libext2_readdir(void *info, oid_t *oid, off_t offs, struct dirent *dent, size_t size)
 {
 	return ext2_read((ext2_t *)info, oid->id, offs, (char *)dent, size);
 }

--- a/ext2/libext2.h
+++ b/ext2/libext2.h
@@ -40,7 +40,7 @@ extern int libext2_unmount(void *fdata);
 
 
 /* Mounts filesystem */
-extern int libext2_mount(oid_t *dev, unsigned int sectorsz, ssize_t (*read)(id_t, offs_t, char *, size_t), ssize_t (*write)(id_t, offs_t, const char *, size_t), void **fdata);
+extern int libext2_mount(oid_t *dev, unsigned int sectorsz, ssize_t (*read)(id_t, off_t, char *, size_t), ssize_t (*write)(id_t, off_t, const char *, size_t), void **fdata);
 
 /* Unmount filesystem callback for libstorage */
 extern int libext2_storage_umount(storage_fs_t *fs);

--- a/fat/fatchain.c
+++ b/fat/fatchain.c
@@ -91,8 +91,8 @@ fat_cluster_t fatchain_scanFreeSpace(fat_info_t *info)
 
 	uint32_t buff[16];
 	/* The first two entries in FAT are reserved, but they are always non-zero */
-	offs_t byteOff = info->fatoffBytes;
-	offs_t byteEnd = byteOff + (info->dataClusters + RSVD_ENTRIES) * ((info->type == FAT32) ? 4 : 2);
+	off_t byteOff = info->fatoffBytes;
+	off_t byteEnd = byteOff + (info->dataClusters + RSVD_ENTRIES) * ((info->type == FAT32) ? 4 : 2);
 
 	while (byteOff < byteEnd) {
 		size_t toRead = min(sizeof(buff), byteEnd - byteOff);

--- a/fat/fatdev.c
+++ b/fat/fatdev.c
@@ -22,10 +22,10 @@
 #include "fatdev.h"
 
 
-int fatdev_read(fat_info_t *info, offs_t off, size_t size, void *buff)
+int fatdev_read(fat_info_t *info, off_t off, size_t size, void *buff)
 {
 	storage_t *strg = info->strg;
-	offs_t offs = info->strg->start + off;
+	off_t offs = info->strg->start + off;
 	ssize_t size_ret = strg->dev->blk->ops->read(strg, offs, buff, size);
 	if (size_ret != size) {
 		if (size_ret < 0) {

--- a/fat/fatdev.h
+++ b/fat/fatdev.h
@@ -19,7 +19,7 @@
 
 #include "fatio.h"
 
-extern int fatdev_read(fat_info_t *info, offs_t off, size_t size, void *buff);
+extern int fatdev_read(fat_info_t *info, off_t off, size_t size, void *buff);
 
 
 #endif /* _FATDEV_H_ */

--- a/fat/fatio.c
+++ b/fat/fatio.c
@@ -552,7 +552,7 @@ int fatio_lookupPath(fat_info_t *info, const char *path, fat_dirent_t *d, fat_fi
 }
 
 
-ssize_t fatio_read(fat_info_t *info, fatchain_cache_t *c, offs_t offset, size_t size, void *buff)
+ssize_t fatio_read(fat_info_t *info, fatchain_cache_t *c, off_t offset, size_t size, void *buff)
 {
 	size_t totalRead = 0;
 

--- a/fat/fatio.h
+++ b/fat/fatio.h
@@ -65,7 +65,7 @@ typedef struct _fat_info_t {
 	fat_type_t type;
 	fat_bsbpbUnpacked_t bsbpb;
 
-	offs_t fatoffBytes;         /* Start of first FAT (in bytes) */
+	off_t fatoffBytes;          /* Start of first FAT (in bytes) */
 	fat_sector_t rootoff;       /* Start of root directory (for FAT12/16) */
 	fat_sector_t dataoff;       /* Start of data space */
 	fat_cluster_t dataClusters; /* Total clusters in data space */
@@ -149,7 +149,7 @@ typedef int (*fat_dirScanCb_t)(void *arg, fat_dirent_t *d, fat_name_t *name, uin
 extern int fatio_dirScan(fat_info_t *info, fatchain_cache_t *c, uint32_t offset, fat_dirScanCb_t cb, void *cbArg);
 
 
-extern ssize_t fatio_read(fat_info_t *info, fatchain_cache_t *c, offs_t offset, size_t size, void *buff);
+extern ssize_t fatio_read(fat_info_t *info, fatchain_cache_t *c, off_t offset, size_t size, void *buff);
 
 
 /* Lookup path from root to end (d is output only) */

--- a/fat/libfat.c
+++ b/fat/libfat.c
@@ -90,7 +90,7 @@ static fat_obj_t *libfat_findObj(fat_info_t *info, id_t id)
 }
 
 
-ssize_t libfat_write(void *info, oid_t *oid, offs_t offs, const void *data, size_t len)
+ssize_t libfat_write(void *info, oid_t *oid, off_t offs, const void *data, size_t len)
 {
 	return -EROFS;
 }
@@ -296,7 +296,7 @@ static int libfat_close(void *infoVoid, oid_t *oid)
 }
 
 
-ssize_t libfat_read(void *infoVoid, oid_t *oid, offs_t offs, void *data, size_t len)
+ssize_t libfat_read(void *infoVoid, oid_t *oid, off_t offs, void *data, size_t len)
 {
 	if (infoVoid == NULL) {
 		return -EINVAL;
@@ -363,7 +363,7 @@ static int libfat_readdirCb(void *argVoid, fat_dirent_t *d, fat_name_t *name, ui
 }
 
 
-static int libfat_readdir(void *infoVoid, oid_t *oid, offs_t offs, struct dirent *dent, size_t size)
+static int libfat_readdir(void *infoVoid, oid_t *oid, off_t offs, struct dirent *dent, size_t size)
 {
 	if (infoVoid == NULL) {
 		return -EINVAL;

--- a/jffs2/libjffs2.c
+++ b/jffs2/libjffs2.c
@@ -670,7 +670,7 @@ static int libjffs2_destroy(void *info, oid_t *oid)
 }
 
 
-static int libjffs2_readdir(void *info, oid_t *dir, offs_t offs, struct dirent *dent, size_t size)
+static int libjffs2_readdir(void *info, oid_t *dir, off_t offs, struct dirent *dent, size_t size)
 {
 	struct inode *inode;
 	struct file file;
@@ -749,7 +749,7 @@ static int libjffs2_close(void *info, oid_t *oid)
 }
 
 
-static int libjffs2_read(void *info, oid_t *oid, offs_t offs, void *data, size_t len)
+static int libjffs2_read(void *info, oid_t *oid, off_t offs, void *data, size_t len)
 {
 	struct inode *inode;
 	struct jffs2_inode_info *f;
@@ -891,7 +891,7 @@ static int libjffs2_prepareWrite(struct inode *inode, loff_t offs, size_t len)
 }
 
 
-static int libjffs2_write(void *info, oid_t *oid, offs_t offs, const void *data, size_t len)
+static int libjffs2_write(void *info, oid_t *oid, off_t offs, const void *data, size_t len)
 {
 	struct inode *inode;
 	struct jffs2_inode_info *f;

--- a/meterfs/libstorage/meterfs_storage.c
+++ b/meterfs/libstorage/meterfs_storage.c
@@ -70,7 +70,7 @@ static int fsOpAdapter_close(void *info, oid_t *oid)
 }
 
 
-static ssize_t fsOpAdapter_read(void *info, oid_t *oid, offs_t offs, void *data, size_t len)
+static ssize_t fsOpAdapter_read(void *info, oid_t *oid, off_t offs, void *data, size_t len)
 {
 	int err;
 	meterfs_partition_t *ctx = (meterfs_partition_t *)info;
@@ -84,7 +84,7 @@ static ssize_t fsOpAdapter_read(void *info, oid_t *oid, offs_t offs, void *data,
 }
 
 
-static ssize_t fsOpAdapter_write(void *info, oid_t *oid, offs_t offs, const void *data, size_t len)
+static ssize_t fsOpAdapter_write(void *info, oid_t *oid, off_t offs, const void *data, size_t len)
 {
 	int err;
 	meterfs_partition_t *ctx = (meterfs_partition_t *)info;


### PR DESCRIPTION
JIRA: RTOS-125

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adapt to the removal of `offs_t` type
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
