### PR TITLE
ext2: fix block allocation error

### DIFF
--- a/ext2/block.c
+++ b/ext2/block.c
@@ -242,7 +242,7 @@ static int ext2_block_create(ext2_t *fs, ext2_obj_t *obj, uint32_t block, uint32
 		}
 	} while (!offset);
 
-	for (i = 0; (i < n) && (offset + i < fs->sb->groupBlocks) && !ext2_checkbit(bmp, offset + i); i++) {
+	for (i = 0; (i < n) && (offset + i <= fs->sb->groupBlocks) && !ext2_checkbit(bmp, offset + i); i++) {
 		if ((err = ext2_block_get(fs, obj, block + i, &bno)) < 0) {
 			free(bmp);
 			return err;
@@ -250,6 +250,11 @@ static int ext2_block_create(ext2_t *fs, ext2_obj_t *obj, uint32_t block, uint32
 
 		ext2_togglebit(bmp, offset + i);
 		*bno = group * fs->sb->groupBlocks + offset + i;
+	}
+
+	if (i == 0) {
+		free(bmp);
+		return -ENOSPC;
 	}
 
 	if ((err = ext2_block_write(fs, fs->gdt[group].blockBmp, bmp, 1)) < 0) {

--- a/ext2/ext2.h
+++ b/ext2/ext2.h
@@ -129,12 +129,13 @@ extern int ext2_statfs(ext2_t *fs, void *buf, size_t len);
 /* Bitmap bit operations */
 static inline uint32_t ext2_findzerobit(uint32_t *bmp, uint32_t size, uint32_t offs)
 {
-	uint32_t len = (size - 1) / (CHAR_BIT * sizeof(uint32_t)) + 1;
-	uint32_t tmp, i;
+	static const uint32_t bitsInElem = CHAR_BIT * sizeof(uint32_t);
+	uint32_t len = ((size - 1) / bitsInElem) + 1;
 
-	for (i = offs / (CHAR_BIT * sizeof(uint32_t)); i < len; i++) {
-		if ((tmp = bmp[i] ^ ~0UL)) {
-			offs = i * (CHAR_BIT * sizeof(uint32_t)) + __builtin_ffsl(tmp);
+	for (uint32_t i = offs / bitsInElem; i < len; i++) {
+		uint32_t bit = __builtin_ffsl(~bmp[i]);
+		if (bit != 0) {
+			offs = (i * bitsInElem) + bit;
 			return (offs > size) ? 0 : offs;
 		}
 	}


### PR DESCRIPTION
Fix error in block allocation function that resulted in freezes if the next available block was the last one in group.

## Description
The error was in `ext2_block_create` because of the comparison `offset + i < fs->sb->groupBlocks` instead of `offset + i <= fs->sb->groupBlocks`. Variable `offset` has values [0 .. `fs->sb->groupBlocks`] inclusive, with 0 indicating invalid value. Due to this faulty comparison, the function sometimes returned `EOK` while setting number of blocks allocated to 0. As a result, the loop in `ext2_block_sync` which uses this function would loop infinitely.

To fix this, the comparison was corrected and an explicit check was added to ensure that `*res` is never set to 0, instead returning with `-ENOSPC`.

Additionally, code style was improved in several functions to make it more in line with MISRA guidelines.

## Motivation and Context
Closes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/927

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
