### PR TITLE
meterfs: Add file payload encryption option

### DIFF
--- a/meterfs/crypt.c
+++ b/meterfs/crypt.c
@@ -1,0 +1,51 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Meterfs cryptography
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Aleksander Kaminski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+
+#include <tinyaes/aes.h>
+#include "crypt.h"
+
+
+static uint8_t *meterfs_ivSerializeU32(uint8_t *buff, uint32_t d)
+{
+	buff[0] = (d >> 0) & 0xff;
+	buff[1] = (d >> 8) & 0xff;
+	buff[2] = (d >> 16) & 0xff;
+	buff[3] = (d >> 24) & 0xff;
+
+	return &buff[4];
+}
+
+
+static inline void meterfs_constructIV(uint8_t *iv, const file_t *f, const entry_t *e)
+{
+	uint8_t *tbuff = meterfs_ivSerializeU32(iv, e->id.no);
+	tbuff = meterfs_ivSerializeU32(tbuff, f->header.sector);
+	tbuff = meterfs_ivSerializeU32(tbuff, f->header.uid);
+	uint32_t t = 0;
+	meterfs_ivSerializeU32(tbuff, t);
+}
+
+
+void meterfs_encrypt(void *buff, size_t bufflen, const uint8_t *key, const file_t *f, const entry_t *e)
+{
+	struct AES_ctx ctx;
+	uint8_t iv[AES_BLOCKLEN];
+
+	meterfs_constructIV(iv, f, e);
+	AES_init_ctx_iv(&ctx, key, iv);
+	AES_CTR_xcrypt_buffer(&ctx, buff, bufflen);
+}

--- a/meterfs/crypt.h
+++ b/meterfs/crypt.h
@@ -1,0 +1,26 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Meterfs cryptography
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Aleksander Kaminski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef METERFS_CRYPT_H_
+#define METERFS_CRYPT_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "files.h"
+
+
+void meterfs_encrypt(void *buff, size_t bufflen, const uint8_t *key, const file_t *f, const entry_t *e);
+
+
+#endif /* METERFS_CRYPT_H_ */

--- a/meterfs/files.h
+++ b/meterfs/files.h
@@ -34,6 +34,8 @@ typedef struct {
 	uint32_t filesz;
 	uint32_t recordsz;
 	char name[8];
+	uint32_t uid;    /* Unique file id, incremented on file header update */
+	uint16_t ncrypt; /* uint16_t for backward compatibility - so checksum is the same */
 } __attribute__((packed)) fileheader_t;
 
 

--- a/meterfs/meterfs.h
+++ b/meterfs/meterfs.h
@@ -17,11 +17,13 @@
 #include <sys/rb.h>
 #include <sys/types.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #define MAX_NAME_LEN 8
 
 /* clang-format off */
-enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_chiperase, meterfs_fsInfo };
+enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_chiperase,
+	meterfs_fsInfo, meterfs_setEncryption, meterfs_setKey };
 /* clang-format on */
 
 
@@ -42,6 +44,15 @@ typedef struct {
 			size_t filesz;
 			size_t recordsz;
 		} resize;
+
+		struct {
+			id_t id;
+			int state;
+		} setEncryption;
+
+		struct {
+			uint8_t key[32];
+		} setKey;
 	};
 } meterfs_i_devctl_t;
 
@@ -52,6 +63,7 @@ typedef struct {
 		size_t filesz;
 		size_t recordsz;
 		size_t recordcnt;
+		int encryption;
 	} info;
 
 	struct {
@@ -73,6 +85,9 @@ typedef struct {
 	unsigned int filecnt;
 
 	rbtree_t nodesTree;
+
+	uint8_t key[32];
+	bool keyInit;
 
 	/* meterfs externals - should be initialized before meterfs_init */
 	size_t sz;


### PR DESCRIPTION
JIRA: NIL-523

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add AES option to meterfs. This change does not compromise existing API nor existing meterfs partitions data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4x6).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-corelibs/pull/53).
- [ ] I will merge this PR by myself when appropriate.
