### PR TITLE
jffs2/phoenix-rtos: add `extern` keyword to init_user_ns

### DIFF
--- a/jffs2/phoenix-rtos.h
+++ b/jffs2/phoenix-rtos.h
@@ -136,7 +136,7 @@ extern unsigned int dirty_writeback_interval; /* centiseconds */
 struct user_namespace {
 };
 
-struct user_namespace init_user_ns;
+extern struct user_namespace init_user_ns;
 
 uid_t from_kuid(struct user_namespace *to, kuid_t kuid);
 

--- a/jffs2/phoenix-rtos/phoenix-rtos.c
+++ b/jffs2/phoenix-rtos/phoenix-rtos.c
@@ -15,6 +15,7 @@
 
 #include "../phoenix-rtos.h"
 
+struct user_namespace init_user_ns;
 unsigned int dirty_writeback_interval = 5 * 100000; /* centiseconds */
 
 void *page_address(const struct page *page)


### PR DESCRIPTION
This is needed to compile with `-fno-common` flag. See https://github.com/phoenix-rtos/phoenix-rtos-build/pull/181

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
