### PR TITLE
meterfs: introduce early erase filesystem option

### DIFF
--- a/meterfs/files.h
+++ b/meterfs/files.h
@@ -15,6 +15,7 @@
 #define _METERFS_FILES_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #define HGRAIN            32u /* Must be able divide sector size */
 #define HEADER_SECTOR_CNT 2u
@@ -61,6 +62,7 @@ typedef struct {
 	index_t firstidx;
 	unsigned int firstoff;
 	unsigned int recordcnt;
+	bool earlyErased;
 } file_t;
 
 

--- a/meterfs/meterfs.h
+++ b/meterfs/meterfs.h
@@ -23,7 +23,7 @@
 
 /* clang-format off */
 enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_chiperase,
-	meterfs_fsInfo, meterfs_setEncryption, meterfs_setKey };
+	meterfs_fsInfo, meterfs_setEncryption, meterfs_setKey, meterfs_setEarlyErase };
 /* clang-format on */
 
 
@@ -53,6 +53,10 @@ typedef struct {
 		struct {
 			uint8_t key[32];
 		} setKey;
+
+		struct {
+			bool enable;
+		} setEarlyErase;
 	};
 } meterfs_i_devctl_t;
 
@@ -71,6 +75,7 @@ typedef struct {
 		size_t sectorsz;
 		size_t fileLimit;
 		size_t filecnt;
+		bool earlyErase;
 	} fsInfo;
 } meterfs_o_devctl_t;
 
@@ -88,6 +93,9 @@ typedef struct {
 
 	uint8_t key[32];
 	bool keyInit;
+
+	/* erase sector for next write early */
+	bool earlyErase;
 
 	/* meterfs externals - should be initialized before meterfs_init */
 	size_t sz;


### PR DESCRIPTION
Erases sector for new record after writing current record. This guarantees that next write will be done quickly because sector is already erased.

JIRA: NIL-585

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
