### PR TITLE
libstorage: Fix meterfs usage, add missing set of keyInit field

### DIFF
--- a/meterfs/libstorage/meterfs_storage.c
+++ b/meterfs/libstorage/meterfs_storage.c
@@ -251,6 +251,7 @@ int meterfs_mount(storage_t *storage, storage_fs_t *fs, const char *data, unsign
 	ctx->meterfsCtx.eraseSector = meterfsAdapter_eraseSector;
 	ctx->meterfsCtx.powerCtrl = meterfsAdapter_powerCtrl;
 	ctx->meterfsCtx.devCtx = &ctx->devCtx;
+	ctx->meterfsCtx.keyInit = false;
 
 	err = meterfs_init(&ctx->meterfsCtx);
 	if (err < 0) {


### PR DESCRIPTION
DONE: RTOS-857

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
