### PR TITLE
ext2: fix deadlock when ext2_obj_get() fails

### DIFF
--- a/ext2/ext2.c
+++ b/ext2/ext2.c
@@ -121,7 +121,7 @@ int ext2_lookup(ext2_t *fs, id_t id, const char *name, size_t len, oid_t *res, o
 
 			obj = ext2_obj_get(fs, res->id);
 			if (obj == NULL) {
-				ext2_unlink(fs, dir->id, name + i, j - i);
+				_ext2_dir_remove(fs, dir, name + i, j - i);
 				err = -ENOENT;
 				break;
 			}


### PR DESCRIPTION
If `ext2_obj_get(fs, res->id)` returned NULL, then `ext2_unlink()` would be called with `dir->lock` already obtained. A call to `ext2_unlink()` also tries to obtain this lock, which resulted in a deadlock.

JIRA: RTOS-933

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: ia32

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
