### PR TITLE
rofs: allow dir names to have common prefix

### DIFF
--- a/rofs/rofs.c
+++ b/rofs/rofs.c
@@ -416,12 +416,11 @@ static int dirfind(struct rofs_ctx *ctx, struct rofs_node **pNode, int parent_id
 
 	for (i = 0; i < ctx->nodeCount; i++) {
 		node = &ctx->tree[i];
-		if ((node->parent_id == parent_id) && (memcmp(name, node->name, len) == 0)) {
-			size_t nlen = strlen(node->name);
+		if ((node->parent_id == parent_id) && (strlen(node->name) == len) && (strncmp(name, node->name, len) == 0)) {
 			o->id = node->id;
 			o->port = ctx->oid.port;
 			*pNode = node;
-			return (nlen == len) ? len : -ENOENT;
+			return len;
 		}
 	}
 


### PR DESCRIPTION
JIRA: RTOS-961

<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously dirfind was broken if there were two folder with common prefix in the name ex `lib` and `libexec`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).
sparc

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
