### PR TITLE
rofs: generalize dev read to allow for indirect memory access

### DIFF
--- a/_targets/Makefile.armv7m7-imxrt106x
+++ b/_targets/Makefile.armv7m7-imxrt106x
@@ -7,4 +7,4 @@
 #
 #
 
-DEFAULT_COMPONENTS := rofs dummyfs libdummyfs libmeterfs
+DEFAULT_COMPONENTS := rofs librofs dummyfs libdummyfs libmeterfs

--- a/rofs/Makefile
+++ b/rofs/Makefile
@@ -4,7 +4,15 @@
 # Copyright 2024 Phoenix Systems
 #
 
+
+NAME := librofs
+LOCAL_SRCS := rofs.c
+LOCAL_HEADERS := rofs.h
+
+include $(static-lib.mk)
+
 NAME := rofs
-LOCAL_SRCS := rofs.c srv.c
+LOCAL_SRCS := srv.c
+LIBS := librofs
 
 include $(binary.mk)

--- a/rofs/rofs.h
+++ b/rofs/rofs.h
@@ -16,7 +16,15 @@
 
 #include <stdint.h>
 #include <sys/types.h>
+#include <sys/file.h>
+#include <sys/msg.h>
 
+
+#define ROFS_BUFSZ (256)
+
+struct rofs_ctx;
+
+typedef int (*rofs_devRead_t)(struct rofs_ctx *ctx, void *buf, size_t len, size_t offset);
 
 struct rofs_ctx {
 	void *imgPtr;
@@ -25,14 +33,23 @@ struct rofs_ctx {
 	uint32_t checksum;
 	struct rofs_node *tree;
 	uint32_t nodeCount;
+	uint32_t indexOffs;
 	oid_t oid;
+
+	rofs_devRead_t devRead;
+
+	uint8_t buf[ROFS_BUFSZ];
 };
 
 
-int rofs_init(struct rofs_ctx *ctx, unsigned long imgAddr);
+/* if imageAddr != 0, maps partition directly; assumes indirect access otherwise */
+int rofs_init(struct rofs_ctx *ctx, rofs_devRead_t devRead, unsigned long imageAddr);
 
 
 void rofs_setdev(struct rofs_ctx *ctx, oid_t *oid);
+
+
+oid_t rofs_getdev(struct rofs_ctx *ctx);
 
 
 int rofs_open(struct rofs_ctx *ctx, oid_t *oid);
@@ -90,6 +107,9 @@ int rofs_mount(struct rofs_ctx *ctx, oid_t *oid, mount_i_msg_t *imnt, mount_o_ms
 
 
 int rofs_unmount(struct rofs_ctx *ctx);
+
+
+void *rofs_getImgPtr(struct rofs_ctx *ctx);
 
 
 #endif /* end of ROFS_H */

--- a/rofs/srv.c
+++ b/rofs/srv.c
@@ -18,10 +18,23 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 #include <unistd.h>
+#include <string.h>
+
 #include "rofs.h"
 
 #define LOG_PREFIX    "rofs: "
 #define LOG(fmt, ...) printf(LOG_PREFIX fmt "\n", ##__VA_ARGS__)
+
+
+static int rofs_ahbRead(struct rofs_ctx *ctx, void *buf, size_t len, size_t offset)
+{
+	void *ptr = rofs_getImgPtr(ctx);
+	if (ptr == NULL) {
+		return -EINVAL;
+	}
+	memcpy(buf, (uint8_t *)ptr + offset, len);
+	return len;
+}
 
 
 static int mount_oid(const char *mntPoint, oid_t *oid)
@@ -99,7 +112,7 @@ int main(int argc, char **argv)
 
 
 	/* address in AHB memory where whole ROFS image is loaded by other process */
-	if (rofs_init(&ctx, imgAddr) < 0) {
+	if (rofs_init(&ctx, rofs_ahbRead, imgAddr) < 0) {
 		LOG("error");
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Currently rofs assumes the partition to be accessible from AHB. This change allows for defining custom dev read handlers to get rid of this assumption and using some intermediary IO provider (e.g. flashsrv)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: nilee

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
