### PR TITLE
meterfs: Start file id's from 1

### DIFF
--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -697,7 +697,7 @@ static int meterfs_rbTreeFill(meterfs_ctx_t *ctx)
 			break;
 		}
 
-		err = node_add(&f, (id_t)i, &ctx->nodesTree);
+		err = node_add(&f, (id_t)(i + 1), &ctx->nodesTree);
 		if (err < 0) {
 			ret = err;
 			break;
@@ -1119,7 +1119,8 @@ int meterfs_allocateFile(const char *name, size_t sectorcnt, size_t filesz, size
 
 	meterfs_powerCtrl(0, ctx);
 
-	err = node_add(&f, (id_t)ctx->filecnt, &ctx->nodesTree);
+	/* Files starts from 1, add 1 to filecnt */
+	err = node_add(&f, (id_t)(ctx->filecnt + 1), &ctx->nodesTree);
 	if (err < 0)
 		return err;
 


### PR DESCRIPTION
Common usage of meterfs involves using static fd table in zeroed bss. This causes that programmer error (eg. invalid initialisation) can lead to weird and hard to identify errors, that someone writes to firstly created file, instead of proper one.

Starting id from 1 can help to avoid that kind of issues.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/408
- [x] Tested by hand on: host-generic-pc, NIL, EBRO

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
