### PR TITLE
backport to release/3.3: !meterfs: add (fast) meterfs_erase operation

### DIFF
--- a/meterfs/files.h
+++ b/meterfs/files.h
@@ -51,6 +51,7 @@ typedef struct {
 	uint32_t filecnt;
 	uint32_t checksum;
 	unsigned char magic[4];
+	uint8_t version;
 } __attribute__((packed)) header_t;
 
 _Static_assert(sizeof(header_t) <= HGRAIN);

--- a/meterfs/files.h
+++ b/meterfs/files.h
@@ -24,20 +24,26 @@
 
 
 typedef struct {
-	unsigned int nvalid:1;
-	unsigned int no:31;
+	unsigned int nvalid : 1;
+	unsigned int no : 31;
 } __attribute__((packed)) index_t;
+
+_Static_assert(sizeof(index_t) <= HGRAIN);
 
 
 typedef struct {
 	unsigned int sector;
-	uint32_t sectorcnt;
 	uint32_t filesz;
 	uint32_t recordsz;
 	char name[8];
-	uint32_t uid;    /* Unique file id, incremented on file header update */
-	uint16_t ncrypt; /* uint16_t for backward compatibility - so checksum is the same */
+	uint32_t uid;     /* Unique file id, incremented on file header update */
+	uint32_t firstid; /* First entry id of current file contents - any entries with lower id are ignored */
+	uint32_t sectorcnt : 17;
+	uint32_t ncrypt : 1;
+	uint32_t unused : 14; /* Unused bits for future use */
 } __attribute__((packed)) fileheader_t;
+
+_Static_assert(sizeof(fileheader_t) <= HGRAIN);
 
 
 typedef struct {
@@ -47,12 +53,16 @@ typedef struct {
 	unsigned char magic[4];
 } __attribute__((packed)) header_t;
 
+_Static_assert(sizeof(header_t) <= HGRAIN);
+
 
 typedef struct {
 	index_t id;
 	uint32_t checksum;
 	unsigned char data[];
 } __attribute__((packed)) entry_t;
+
+_Static_assert(sizeof(entry_t) <= HGRAIN);
 
 
 typedef struct {

--- a/meterfs/files.h
+++ b/meterfs/files.h
@@ -77,4 +77,30 @@ typedef struct {
 } file_t;
 
 
+/* pre-v1 typedefs - used for migration */
+
+
+typedef struct {
+	unsigned int sector;
+	uint32_t sectorcnt;
+	uint32_t filesz;
+	uint32_t recordsz;
+	char name[8];
+	uint32_t uid;    /* Unique file id, incremented on file header update */
+	uint16_t ncrypt; /* uint16_t for backward compatibility - so checksum is the same */
+} __attribute__((packed)) fileheaderOld_t;
+
+_Static_assert(sizeof(fileheaderOld_t) <= HGRAIN);
+
+
+typedef struct {
+	index_t id;
+	uint32_t filecnt;
+	uint32_t checksum;
+	unsigned char magic[4];
+} __attribute__((packed)) headerOld_t;
+
+_Static_assert(sizeof(headerOld_t) <= HGRAIN);
+
+
 #endif

--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -384,7 +384,7 @@ static int meterfs_isHeaderValid(unsigned int headerIdx, index_t *id, unsigned i
 	}
 
 	if (checksum != 0) {
-		LOG_INFO("meterfs: header bad checksum 0x04%x", checksum);
+		LOG_INFO("meterfs: header bad checksum 0x%04x", checksum);
 	}
 
 	return (checksum == 0);
@@ -470,7 +470,7 @@ static int meterfs_migrateFileTable(unsigned int srcIdx, unsigned int srcFilecnt
 		do {
 			err = meterfs_writeVerify(fileheaderAddrOfs + dst, &new, sizeof(new), ctx);
 			retry++;
-		} while (err < 0 || retry < writeAttempts);
+		} while (err < 0 && retry < writeAttempts);
 		if (err < 0) {
 			return err;
 		}
@@ -499,7 +499,7 @@ static int meterfs_migrateFileTable(unsigned int srcIdx, unsigned int srcFilecnt
 	do {
 		err = meterfs_writeVerify(ctx->offset + dst, &u.h, sizeof(u.h), ctx);
 		retry++;
-	} while (err < 0 || retry < writeAttempts);
+	} while (err < 0 && retry < writeAttempts);
 	if (err < 0) {
 		return err;
 	}
@@ -534,7 +534,7 @@ static int meterfs_migrateFileTable(unsigned int srcIdx, unsigned int srcFilecnt
 	do {
 		err = meterfs_copyData(ctx->offset + src, ctx->offset + dst, HGRAIN * (ctx->filecnt + 1), ctx);
 		retry++;
-	} while (err < 0 || retry < writeAttempts);
+	} while (err < 0 && retry < writeAttempts);
 	if (err < 0) {
 		return err;
 	}

--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -51,9 +51,13 @@ static struct {
 #warning "meterfs UNRELIABLE_WRITE is ON. Did you really intend that?"
 #endif
 
+
+/* pre-v1 magic - used for migration */
+static const unsigned char magicConstOld[4] = { 0x66, 0x41, 0x4b, 0xbb };
+
 static const unsigned char magicConst[4] = { 0x6d, 0x74, 0x72, 0x0a };
 
-static const uint8_t meterfsVersion = 0x01;
+static const uint8_t meterfsVersion = 0x01; /* v1 */
 
 
 struct partialEraseJournal_s {
@@ -308,11 +312,249 @@ static int meterfs_eraseFileTable(unsigned int n, meterfs_ctx_t *ctx)
 }
 
 
+static int meterfs_isHeaderValid(unsigned int headerIdx, index_t *id, unsigned int *filecnt, bool *mustMigrate, meterfs_ctx_t *ctx)
+{
+	ssize_t err;
+	union {
+		header_t h;
+		fileheader_t f;
+	} u;
+	bool headerOk = false;
+	bool migrate = false;
+
+	err = ctx->read(ctx->devCtx, ctx->offset + (headerIdx * ctx->h1Addr), &u.h, sizeof(u.h));
+	if (err < 0) {
+		return err;
+	}
+
+	headerOk = false;
+	if (u.h.id.nvalid == 0) {
+		if (memcmp(u.h.magic, magicConst, 4) == 0 && (u.h.version == meterfsVersion)) {
+			headerOk = true;
+		}
+		else if (memcmp(u.h.magic, magicConstOld, 4) == 0) {
+			LOG_INFO("meterfs: Old magic detected in header #%u", headerIdx);
+			headerOk = true;
+			migrate = true;
+		}
+	}
+
+	if (!headerOk) {
+		return 0;
+	}
+
+	/*
+	 * When migrating, we can refer to old headerOld_t as u.h as they are
+	 * structurally the same except the last uint8_t ver field (added in v1)
+	 */
+
+	uint32_t fileheaderSize = migrate ? sizeof(fileheaderOld_t) : sizeof(fileheader_t);
+	uint32_t headerSize = migrate ? sizeof(headerOld_t) : sizeof(header_t);
+
+	uint32_t checksum = meterfs_calcChecksum(&u.h, headerSize);
+	uint32_t savedFilecnt = u.h.filecnt;
+
+	if (id != NULL) {
+		*id = u.h.id;
+	}
+
+	if (filecnt != NULL) {
+		*filecnt = u.h.filecnt;
+	}
+
+	if (mustMigrate != NULL) {
+		*mustMigrate = migrate;
+	}
+
+	for (uint32_t i = 0; i < savedFilecnt; ++i) {
+		/*
+		 * We destroy the header (as it's a part of a union)!. But it's ok, we only
+		 * need to check if checksum == 0
+		 */
+		err = ctx->read(ctx->devCtx, ctx->offset + (headerIdx * ctx->h1Addr) + HGRAIN + (i * HGRAIN), &u.f, fileheaderSize);
+		if (err < 0) {
+			return err;
+		}
+
+		checksum ^= meterfs_calcChecksum(&u.f, fileheaderSize);
+	}
+
+	if (checksum != 0) {
+		LOG_INFO("meterfs: header bad checksum 0x04%x", checksum);
+	}
+
+	return (checksum == 0);
+}
+
+
+/* A damaged filetable header can be fixed as there should be a copy of file table at all times. */
+static int meterfs_fixFileTable(unsigned int fixIdx, unsigned int backupFilecnt, meterfs_ctx_t *ctx)
+{
+	int err;
+
+	LOG_INFO("meterfs: Filetable header #%u is damaged - repairing.", fixIdx);
+	uint32_t src = (fixIdx == 0) ? ctx->h1Addr : 0;
+	uint32_t dst = (fixIdx == 0) ? 0 : ctx->h1Addr;
+	err = meterfs_eraseFileTable(fixIdx, ctx);
+	if (err < 0) {
+		return err;
+	}
+
+	ctx->hcurrAddr = src;
+	ctx->filecnt = backupFilecnt;
+
+	err = meterfs_copyData(ctx->offset + dst, ctx->offset + src, HGRAIN * (ctx->filecnt + 1), ctx);
+	if (err < 0) {
+		return err;
+	}
+
+	return 0;
+}
+
+
+static int meterfs_migrateFileTable(unsigned int srcIdx, unsigned int srcFilecnt, unsigned int writeAttempts, meterfs_ctx_t *ctx)
+{
+	ssize_t err;
+	union {
+		header_t h;
+		fileheader_t f;
+		headerOld_t hOld;
+		fileheaderOld_t fOld;
+	} u;
+	unsigned int dstIdx = 1 - srcIdx;
+	unsigned int retry = 0;
+
+	unsigned int src = srcIdx * ctx->h1Addr;
+	unsigned int dst = dstIdx * ctx->h1Addr;
+
+	LOG_INFO("meterfs: Migrating header #%u to #%u", srcIdx, dstIdx);
+
+	err = meterfs_eraseFileTable(dstIdx, ctx);
+	if (err < 0) {
+		return err;
+	}
+
+	uint32_t checksum = 0;
+
+	for (uint32_t i = 0; i < srcFilecnt; ++i) {
+		off_t fileheaderAddrOfs = ctx->offset + HGRAIN + (i * HGRAIN);
+
+		err = ctx->read(ctx->devCtx, fileheaderAddrOfs + src, &u.fOld, sizeof(u.fOld));
+		if (err < 0) {
+			return err;
+		}
+
+		/* rewrite the header */
+		fileheader_t new;
+		new.sector = u.fOld.sector;
+		new.filesz = u.fOld.filesz;
+		new.recordsz = u.fOld.recordsz;
+		memcpy(new.name, u.fOld.name, sizeof(new.name));
+		new.uid = u.fOld.uid;
+		new.firstid = 0;
+		new.sectorcnt = u.fOld.sectorcnt;
+		new.ncrypt = u.fOld.ncrypt != 0 ? 1 : 0;
+		new.unused = 0;
+
+#if UNRELIABLE_WRITE
+		if (++debug_common.wrreboot > UNRELIABLE_WRITE_REBOOT) {
+			LOG_DEBUG("Unreliable write trigger - reboot during migration");
+			reboot(PHOENIX_REBOOT_MAGIC);
+		}
+#endif
+
+		retry = 0;
+		do {
+			err = meterfs_writeVerify(fileheaderAddrOfs + dst, &new, sizeof(new), ctx);
+			retry++;
+		} while (err < 0 || retry < writeAttempts);
+		if (err < 0) {
+			return err;
+		}
+
+		checksum ^= meterfs_calcChecksum(&new, sizeof(new));
+	}
+
+	/* read old header */
+	err = ctx->read(ctx->devCtx, ctx->offset + src, &u.h, sizeof(u.hOld));
+	if (err < 0) {
+		return err;
+	}
+
+	/* fill new fields */
+	u.h.version = meterfsVersion;
+
+	/* migrate header */
+	memcpy(u.h.magic, magicConst, sizeof(magicConst));
+	u.h.checksum = 0; /* 0 is a neutral value for BCC checksum */
+	u.h.checksum = checksum ^ meterfs_calcChecksum(&u.h, sizeof(u.h));
+
+	/* write migrated header */
+	retry = 0;
+	do {
+		err = meterfs_writeVerify(ctx->offset + dst, &u.h, sizeof(u.h), ctx);
+		retry++;
+	} while (err < 0 || retry < writeAttempts);
+	if (err < 0) {
+		return err;
+	}
+
+	LOG_INFO("meterfs: Migrated header to #%u", dstIdx);
+
+	bool migrate = false;
+	if (!meterfs_isHeaderValid(dstIdx, NULL, NULL, &migrate, ctx)) {
+		LOG_INFO("meterfs: Header #%u invalid after migration", dstIdx);
+		return -1;
+	}
+
+	if (migrate) {
+		LOG_INFO("meterfs: Migration had no effect!");
+		return -1;
+	}
+
+#if UNRELIABLE_WRITE
+	if (++debug_common.wrreboot > UNRELIABLE_WRITE_REBOOT) {
+		LOG_DEBUG("Unreliable write trigger - reboot during migration");
+		reboot(PHOENIX_REBOOT_MAGIC);
+	}
+#endif
+
+	LOG_INFO("meterfs: Copying migrated header #%u to #%u", dstIdx, srcIdx);
+	err = meterfs_eraseFileTable(srcIdx, ctx);
+	if (err < 0) {
+		return err;
+	}
+
+	ctx->hcurrAddr = dst;
+	ctx->filecnt = srcFilecnt;
+
+	retry = 0;
+	do {
+		err = meterfs_copyData(ctx->offset + src, ctx->offset + dst, HGRAIN * (ctx->filecnt + 1), ctx);
+		retry++;
+	} while (err < 0 || retry < writeAttempts);
+	if (err < 0) {
+		return err;
+	}
+
+	if (!meterfs_isHeaderValid(srcIdx, NULL, NULL, NULL, ctx)) {
+		LOG_INFO("meterfs: Header #%u invalid after copying", srcIdx);
+		return -1;
+	}
+
+	LOG_INFO("meterfs: Migrated successfully");
+
+	return 0;
+}
+
+
 static int meterfs_checkfs(meterfs_ctx_t *ctx)
 {
 	bool valid[2] = { false, false };
+	bool migrate[2] = { false, false };
 	index_t id[2];
 	unsigned int filecnt[2];
+	const unsigned int attempts = 3;
 	ssize_t err;
 	union {
 		header_t h;
@@ -323,38 +565,63 @@ static int meterfs_checkfs(meterfs_ctx_t *ctx)
 
 	meterfs_powerCtrl(1, ctx);
 
-	for (unsigned int retry = 0; retry < 3; ++retry) {
+	for (unsigned int retry = 0; retry < attempts; ++retry) {
 		for (unsigned int headerIdx = 0; headerIdx < 2; ++headerIdx) {
-			err = ctx->read(ctx->devCtx, ctx->offset + (headerIdx * ctx->h1Addr), &u.h, sizeof(u.h));
+			err = meterfs_isHeaderValid(headerIdx, &id[headerIdx], &filecnt[headerIdx], &migrate[headerIdx], ctx);
 			if (err < 0) {
 				meterfs_powerCtrl(0, ctx);
 				return err;
 			}
-
-			if ((u.h.id.nvalid == 0) && (memcmp(u.h.magic, magicConst, 4) == 0) && (u.h.version == meterfsVersion)) {
-				id[headerIdx] = u.h.id;
-				filecnt[headerIdx] = u.h.filecnt;
-
-				uint32_t checksum = meterfs_calcChecksum(&u.h, sizeof(u.h));
-				uint32_t filecnt = u.h.filecnt;
-				for (uint32_t i = 0; i < filecnt; ++i) {
-					/* We destroy the header (as it's a part of a union)!. But it's ok, we only
-					 * need to check if checksum == 0 */
-					err = ctx->read(ctx->devCtx, ctx->offset + (headerIdx * ctx->h1Addr) + HGRAIN + (i * HGRAIN), &u.f, sizeof(u.f));
-					if (err < 0) {
-						meterfs_powerCtrl(0, ctx);
-						return err;
-					}
-
-					checksum ^= meterfs_calcChecksum(&u.f, sizeof(u.f));
-				}
-
-				valid[headerIdx] = (checksum == 0);
-			}
+			valid[headerIdx] = err;
 		}
 
-		if (valid[0] && valid[1]) {
+		bool both_valid = valid[0] && valid[1];
+
+		if (both_valid && !migrate[0] && !migrate[1]) {
 			break;
+		}
+
+		if (migrate[0] || migrate[1]) {
+			if (both_valid) {
+				LOG_INFO("meterfs: Valid old partition detected. Migrating.");
+
+				unsigned int src;
+				if (migrate[0] && migrate[1]) {
+					/* pick the newer header as src */
+					src = id[0].no + 1 == id[1].no ? 1 : 0;
+				}
+				else {
+					/* continue interrupted migration */
+					src = migrate[0] ? 0 : 1;
+				}
+
+				for (unsigned int retry = 0; retry < attempts; ++retry) {
+					err = meterfs_migrateFileTable(src, filecnt[src], attempts, ctx);
+					if (err < 0) {
+						LOG_INFO("meterfs: Migration attempt %u failed (%zu)", retry, err);
+					}
+					else {
+						break;
+					}
+				}
+
+				if (err < 0) {
+					LOG_INFO("meterfs: Migration failed despite %u attempts", attempts);
+					meterfs_powerCtrl(0, ctx);
+					return err;
+				}
+
+				break;
+			}
+			else {
+				/* One of the headers got damaged, potentially during migration */
+				unsigned int fixIdx = valid[0] ? 1 : 0;
+				err = meterfs_fixFileTable(fixIdx, filecnt[(fixIdx == 0) ? 1 : 0], ctx);
+				if (err < 0) {
+					meterfs_powerCtrl(0, ctx);
+					return err;
+				}
+			}
 		}
 	}
 
@@ -407,22 +674,8 @@ static int meterfs_checkfs(meterfs_ctx_t *ctx)
 		}
 	}
 	else {
-		/* There should be a copy of file table at all times. Fix it if necessary */
 		unsigned int fixIdx = valid[0] ? 1 : 0;
-
-		LOG_INFO("meterfs: Filetable header #%u is damaged - repairing.", fixIdx);
-		uint32_t src = (fixIdx == 0) ? ctx->h1Addr : 0;
-		uint32_t dst = (fixIdx == 0) ? 0 : ctx->h1Addr;
-		err = meterfs_eraseFileTable(fixIdx, ctx);
-		if (err < 0) {
-			meterfs_powerCtrl(0, ctx);
-			return err;
-		}
-
-		ctx->hcurrAddr = src;
-		ctx->filecnt = filecnt[(fixIdx == 0) ? 1 : 0];
-
-		err = meterfs_copyData(ctx->offset + dst, ctx->offset + src, HGRAIN * (ctx->filecnt + 1), ctx);
+		err = meterfs_fixFileTable(fixIdx, filecnt[(fixIdx == 0) ? 1 : 0], ctx);
 		if (err < 0) {
 			meterfs_powerCtrl(0, ctx);
 			return err;

--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -51,7 +51,10 @@ static struct {
 #warning "meterfs UNRELIABLE_WRITE is ON. Did you really intend that?"
 #endif
 
-static const unsigned char magicConst[4] = { 0x66, 0x41, 0x4b, 0xbb };
+static const unsigned char magicConst[4] = { 0x6d, 0x74, 0x72, 0x0a };
+
+static const uint8_t meterfsVersion = 0x01;
+
 
 struct partialEraseJournal_s {
 	unsigned int sector;
@@ -328,7 +331,7 @@ static int meterfs_checkfs(meterfs_ctx_t *ctx)
 				return err;
 			}
 
-			if ((u.h.id.nvalid == 0) && (memcmp(u.h.magic, magicConst, 4) == 0)) {
+			if ((u.h.id.nvalid == 0) && (memcmp(u.h.magic, magicConst, 4) == 0) && (u.h.version == meterfsVersion)) {
 				id[headerIdx] = u.h.id;
 				filecnt[headerIdx] = u.h.filecnt;
 
@@ -369,6 +372,7 @@ static int meterfs_checkfs(meterfs_ctx_t *ctx)
 		u.h.id.nvalid = 0;
 		u.h.checksum = 0;
 		memcpy(u.h.magic, magicConst, 4);
+		u.h.version = meterfsVersion;
 
 		uint32_t checksum = meterfs_calcChecksum(&u.h, sizeof(u.h));
 		u.h.checksum = checksum;

--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -343,7 +343,7 @@ static int meterfs_isHeaderValid(unsigned int headerIdx, index_t *id, unsigned i
 		}
 	}
 
-	if (!headerOk) {
+	if (!headerOk || u.h.filecnt > MAX_FILE_CNT(ctx->sectorsz)) {
 		return 0;
 	}
 

--- a/meterfs/meterfs.c
+++ b/meterfs/meterfs.c
@@ -11,6 +11,7 @@
  * %LICENSE%
  */
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -39,16 +40,36 @@
 #define JOURNAL_OFFSET(ssz)       (2 * HEADER_SIZE(ssz))
 #define SPARE_SECTOR_OFFSET(ssz)  (JOURNAL_OFFSET(ssz) + (ssz))
 
-#define UNRELIABLE_WRITE 0 /* DEBUG ONLY! */
-#if UNRELIABLE_WRITE
+#if METERFS_DEBUG_UTILS
 static struct {
 	int rwcnt;
 	int wrreboot;
+	meterfs_debugCtx_t ctx;
 } debug_common;
-#define UNRELIABLE_WRITE_TRIGGER        32
-#define UNRELIABLE_WRITE_REBOOT         1
-#define UNRELIABLE_WRITE_REBOOT_TRIGGER 5
-#warning "meterfs UNRELIABLE_WRITE is ON. Did you really intend that?"
+
+#define DEBUG_UNRELIABLE_WRITE_TRIGGER(msg) \
+	do { \
+		if (debug_common.ctx.unreliableWriteTrigger > 0 && ++debug_common.rwcnt >= debug_common.ctx.unreliableWriteTrigger) { \
+			LOG_DEBUG("Unreliable write trigger - " msg); \
+			debug_common.rwcnt = 0; \
+			return -EIO; \
+		} \
+	} while (0)
+
+#define DEBUG_REBOOT_TRIGGER(msg) \
+	do { \
+		if (debug_common.ctx.rebootTrigger > 0 && ++debug_common.wrreboot >= debug_common.ctx.rebootTrigger) { \
+			if (debug_common.ctx.onRebootCb != NULL) { \
+				LOG_DEBUG("Reboot trigger - " msg); \
+				debug_common.ctx.onRebootCb(); \
+			} \
+		} \
+	} while (0)
+
+#pragma message("meterfs METERFS_DEBUG_UTILS is ON!")
+#else
+#define DEBUG_UNRELIABLE_WRITE_TRIGGER(msg)
+#define DEBUG_REBOOT_TRIGGER(msg)
 #endif
 
 
@@ -96,13 +117,7 @@ static ssize_t meterfs_writeVerify(unsigned int addr, const void *buff, size_t b
 	unsigned char vbuff[32];
 	size_t i, chunk;
 
-#if UNRELIABLE_WRITE
-	if (++debug_common.rwcnt > UNRELIABLE_WRITE_TRIGGER) {
-		LOG_DEBUG("Unreliable write trigger - write");
-		debug_common.rwcnt = 0;
-		return -EIO;
-	}
-#endif
+	DEBUG_UNRELIABLE_WRITE_TRIGGER("write");
 
 	err = ctx->write(ctx->devCtx, addr, buff, bufflen);
 	if (err < 0)
@@ -117,13 +132,7 @@ static ssize_t meterfs_writeVerify(unsigned int addr, const void *buff, size_t b
 		if (err < 0)
 			return err;
 
-#if UNRELIABLE_WRITE
-		if (++debug_common.rwcnt > UNRELIABLE_WRITE_TRIGGER) {
-			LOG_DEBUG("Unreliable write trigger - verify");
-			debug_common.rwcnt = 0;
-			return -EIO;
-		}
-#endif
+		DEBUG_UNRELIABLE_WRITE_TRIGGER("verify");
 
 		if (memcmp((const unsigned char *)buff + i, vbuff, chunk))
 			return -EIO;
@@ -142,7 +151,7 @@ static ssize_t meterfs_copyData(unsigned int dst, unsigned int src, size_t len, 
 	for (offs = 0; offs < len; offs += chunk) {
 		chunk = (offs + sizeof(buff) >= len) ? len - offs : sizeof(buff);
 
-#if UNRELIABLE_WRITE
+#if METERFS_DEBUG_UTILS
 		/* Let it copy data... We need to do partial erase */
 		debug_common.rwcnt = 0;
 #endif
@@ -249,12 +258,7 @@ static int meterfs_startPartialErase(uint32_t addr, meterfs_ctx_t *ctx)
 			break;
 		}
 
-#if UNRELIABLE_WRITE
-		if (++debug_common.wrreboot > UNRELIABLE_WRITE_REBOOT) {
-			LOG_DEBUG("Unreliable write trigger - reboot during partial erase");
-			reboot(PHOENIX_REBOOT_MAGIC);
-		}
-#endif
+		DEBUG_REBOOT_TRIGGER("during partial erase");
 
 		/* Now finish the operation */
 		err = meterfs_doPartialErase(ctx);
@@ -400,6 +404,8 @@ static int meterfs_fixFileTable(unsigned int fixIdx, unsigned int backupFilecnt,
 		return err;
 	}
 
+	DEBUG_REBOOT_TRIGGER("in fixFileTable between erase and copy");
+
 	ctx->hcurrAddr = src;
 	ctx->filecnt = backupFilecnt;
 
@@ -434,6 +440,8 @@ static int meterfs_migrateFileTable(unsigned int srcIdx, unsigned int srcFilecnt
 		return err;
 	}
 
+	DEBUG_REBOOT_TRIGGER("after dest header erase, before migration");
+
 	uint32_t checksum = 0;
 
 	for (uint32_t i = 0; i < srcFilecnt; ++i) {
@@ -456,12 +464,7 @@ static int meterfs_migrateFileTable(unsigned int srcIdx, unsigned int srcFilecnt
 		new.ncrypt = u.fOld.ncrypt != 0 ? 1 : 0;
 		new.unused = 0;
 
-#if UNRELIABLE_WRITE
-		if (++debug_common.wrreboot > UNRELIABLE_WRITE_REBOOT) {
-			LOG_DEBUG("Unreliable write trigger - reboot during migration");
-			reboot(PHOENIX_REBOOT_MAGIC);
-		}
-#endif
+		DEBUG_REBOOT_TRIGGER("during fileheader migration");
 
 		retry = 0;
 		do {
@@ -489,6 +492,8 @@ static int meterfs_migrateFileTable(unsigned int srcIdx, unsigned int srcFilecnt
 	u.h.checksum = 0; /* 0 is a neutral value for BCC checksum */
 	u.h.checksum = checksum ^ meterfs_calcChecksum(&u.h, sizeof(u.h));
 
+	DEBUG_REBOOT_TRIGGER("before header migration");
+
 	/* write migrated header */
 	retry = 0;
 	do {
@@ -512,12 +517,7 @@ static int meterfs_migrateFileTable(unsigned int srcIdx, unsigned int srcFilecnt
 		return -1;
 	}
 
-#if UNRELIABLE_WRITE
-	if (++debug_common.wrreboot > UNRELIABLE_WRITE_REBOOT) {
-		LOG_DEBUG("Unreliable write trigger - reboot during migration");
-		reboot(PHOENIX_REBOOT_MAGIC);
-	}
-#endif
+	DEBUG_REBOOT_TRIGGER("before erasing copy dest filetable");
 
 	LOG_INFO("meterfs: Copying migrated header #%u to #%u", dstIdx, srcIdx);
 	err = meterfs_eraseFileTable(srcIdx, ctx);
@@ -527,6 +527,8 @@ static int meterfs_migrateFileTable(unsigned int srcIdx, unsigned int srcFilecnt
 
 	ctx->hcurrAddr = dst;
 	ctx->filecnt = srcFilecnt;
+
+	DEBUG_REBOOT_TRIGGER("before copying migrated filetable");
 
 	retry = 0;
 	do {
@@ -628,6 +630,13 @@ static int meterfs_checkfs(meterfs_ctx_t *ctx)
 	if (!valid[0] && !valid[1]) {
 		LOG_INFO("meterfs: No valid filesystem detected. Formating.");
 
+#if METERFS_DEBUG_UTILS
+		if (debug_common.ctx.dryErase) {
+			LOG_INFO("metefs debug: Would erase partition. Exiting.");
+			exit(1);
+		}
+#endif
+
 		/* Not essential, ignore errors */
 		(void)ctx->eraseSector(ctx->devCtx, ctx->offset + JOURNAL_OFFSET(ctx->sectorsz));
 
@@ -647,12 +656,14 @@ static int meterfs_checkfs(meterfs_ctx_t *ctx)
 		for (unsigned int headerIdx = 0; headerIdx < 2; ++headerIdx) {
 			err = meterfs_eraseFileTable(headerIdx, ctx);
 			if (err < 0) {
+				LOG_DEBUG("meterfs: Failed to erase file table.");
 				meterfs_powerCtrl(0, ctx);
 				return err;
 			}
 
 			err = meterfs_writeVerify(ctx->offset + (ctx->h1Addr * headerIdx), &u.h, sizeof(u.h), ctx);
 			if (err < 0) {
+				LOG_DEBUG("meterfs: Failed to write.");
 				meterfs_powerCtrl(0, ctx);
 				return err;
 			}
@@ -1711,9 +1722,6 @@ int meterfs_init(meterfs_ctx_t *ctx)
 
 	/* Don't touch key and keyInit to allow hacky key set by lib user */
 
-#if UNRELIABLE_WRITE
-	LOG_INFO("meterfs UNRELIABLE_WRITE is ON. Did you really intend that?");
-#endif
 	/* clang-format off */
 	if ((ctx == NULL) ||
 			(ctx->sz < (MIN_PARTITIONS_SECTORS_NB * ctx->sectorsz)) ||
@@ -1723,6 +1731,13 @@ int meterfs_init(meterfs_ctx_t *ctx)
 		return -EINVAL;
 	}
 	/* clang-format on */
+
+#if METERFS_DEBUG_UTILS
+	LOG_INFO("meterfs METERFS_DEBUG_UTILS is ON!");
+	debug_common.rwcnt = 0;
+	debug_common.wrreboot = 0;
+	debug_common.ctx = ctx->debugCtx;
+#endif
 
 	node_init(&ctx->nodesTree);
 

--- a/meterfs/meterfs.h
+++ b/meterfs/meterfs.h
@@ -23,7 +23,7 @@
 
 /* clang-format off */
 enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_chiperase,
-	meterfs_fsInfo, meterfs_setEncryption, meterfs_setKey, meterfs_setEarlyErase };
+	meterfs_fsInfo, meterfs_setEncryption, meterfs_setKey, meterfs_setEarlyErase, meterfs_reset };
 /* clang-format on */
 
 

--- a/meterfs/meterfs.h
+++ b/meterfs/meterfs.h
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <board_config.h>
+
 #define MAX_NAME_LEN 8
 
 /* clang-format off */
@@ -26,6 +28,18 @@ enum { meterfs_allocate = 0, meterfs_resize, meterfs_info, meterfs_chiperase,
 	meterfs_fsInfo, meterfs_setEncryption, meterfs_setKey, meterfs_setEarlyErase, meterfs_reset };
 /* clang-format on */
 
+#ifndef METERFS_DEBUG_UTILS
+#define METERFS_DEBUG_UTILS 0
+#endif
+
+#if METERFS_DEBUG_UTILS
+typedef struct {
+	int rebootTrigger;
+	int unreliableWriteTrigger;
+	bool dryErase;
+	void (*onRebootCb)(void);
+} meterfs_debugCtx_t;
+#endif
 
 typedef struct {
 	int type;
@@ -109,6 +123,10 @@ typedef struct {
 	ssize_t (*write)(struct _meterfs_devCtx_t *devCtx, off_t offs, const void *buff, size_t bufflen);
 	int (*eraseSector)(struct _meterfs_devCtx_t *devCtx, off_t offs);
 	void (*powerCtrl)(struct _meterfs_devCtx_t *devCtx, int state);
+
+#if METERFS_DEBUG_UTILS
+	meterfs_debugCtx_t debugCtx;
+#endif
 } meterfs_ctx_t;
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

JIRA: NIL-920

## Description
<!--- Describe your changes shortly -->

Backports https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/159 to release 3.3 branch

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
