### PR TITLE
jffs2: return -ENOENT when no directory was found in readdir

### DIFF
--- a/jffs2/libjffs2.c
+++ b/jffs2/libjffs2.c
@@ -793,6 +793,10 @@ static int libjffs2_readdir(void *info, oid_t *dir, off_t offs, struct dirent *d
 
 	dent->d_reclen = dctx.pos - offs;
 
+	if (dctx.emit == -1) {
+		return -ENOENT;
+	}
+
 	return dctx.emit;
 }
 


### PR DESCRIPTION
readdir() should be able to differentiate between erroneous states and states when there is no more directories in the stream. This requires all filesystems to be consistent with error codes returned for the EOF case.

JIRA: RTOS-1088

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7a9-zynq7000-qemu`.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [X] I will merge this PR by myself when appropriate.
