### PR TITLE
littlefs: use compile-time configuration from board_config.h

### DIFF
--- a/littlefs/include/liblfs.h
+++ b/littlefs/include/liblfs.h
@@ -24,47 +24,33 @@
 #include <liblfs_config.h>
 
 
-#ifndef LIBLFS_CACHESIZE_DEFAULT
 /* NOTE: cache size also determines max size of file that can be inlined in directory structure
  * Any file not inlined WILL take at least 1 full block of storage.
  * See `cache_size` in `struct lfs_config`. */
-#define LIBLFS_CACHESIZE_DEFAULT 256
-#endif
+#define LIBLFS_DEF_CACHESIZE 256
 
-#ifndef LIBLFS_CYCLES_THRESHOLD
 /* Threshold number of erase cycles that trigger wear leveling algorithm. See `block_cycles` in `struct lfs_config`. */
-#define LIBLFS_CYCLES_THRESHOLD 500
-#endif
+#define LIBLFS_DEF_CYCLES_THRESHOLD 500
 
-#ifndef LIBLFS_N_CACHED_OBJECTS
 /* Threshold after which LFS driver will attempt to evict LFS stub objects from memory.
  * Open files/directories are always kept in memory and count towards this limit. */
-#define LIBLFS_N_CACHED_OBJECTS 10
-#endif
+#define LIBLFS_DEF_N_CACHED_OBJECTS 10
 
-#ifndef LIBLFS_LOOKAHEAD_SIZE
 /* Number of blocks to scan ahead when looking for unused blocks. See `lookahead_size` in `struct lfs_config`.*/
-#define LIBLFS_LOOKAHEAD_SIZE 16
-#endif
+#define LIBLFS_DEF_LOOKAHEAD_SIZE 16
 
-#ifndef LIBLFS_LINK_IS_RENAME
 /* If set to 1, "link" filesystem operation works as "rename" - otherwise it returns -ENOSYS.
  * This is a workaround to make it possible to rename files, though with some glitches.
  * TODO: if Phoenix RTOS ever gains support for a proper "rename" operation, fix this. */
-#define LIBLFS_LINK_IS_RENAME 0
-#endif
+#define LIBLFS_DEF_LINK_IS_RENAME 0
 
-#ifndef LIBLFS_MOUNT_FORMAT_OPTION
 /* If set to 1, passing `format` as data to the `mount` command will format the partition with LFS file system.
  * To save some code size, this can be set to 0. */
-#define LIBLFS_MOUNT_FORMAT_OPTION 0
-#endif
+#define LIBLFS_DEF_MOUNT_FORMAT_OPTION 0
 
-#ifndef LIBLFS_FORMAT_ON_MOUNT_FAILURE
 /* If set to 1, a failure to mount the filesystem will result in the driver attempting to format the drive.
  * This is intended for testing, in production it could result in unwanted behavior. */
-#define LIBLFS_FORMAT_ON_MOUNT_FAILURE 0
-#endif
+#define LIBLFS_DEF_FORMAT_ON_MOUNT_FAILURE 0
 
 /* Mount mode flags (`mode` argument to `mount` command)*/
 #define LIBLFS_READ_ONLY_FLAG (1UL << 0) /* Mount in read-only mode */

--- a/littlefs/liblfs.c
+++ b/littlefs/liblfs.c
@@ -21,11 +21,43 @@
 #include <sys/threads.h>
 
 #include <liblfs.h>
+#include <board_config.h>
 
 #include "ph_lfs_api.h"
 #include "ph_lfs_types.h"
 
 #define TRACE_CALLS(x)
+
+/* Set compile-time config values to defaults */
+
+#ifndef LIBLFS_CACHESIZE
+#define LIBLFS_CACHESIZE LIBLFS_DEF_CACHESIZE
+#endif
+
+#ifndef LIBLFS_CYCLES_THRESHOLD
+#define LIBLFS_CYCLES_THRESHOLD LIBLFS_DEF_CYCLES_THRESHOLD
+#endif
+
+#ifndef LIBLFS_N_CACHED_OBJECTS
+#define LIBLFS_N_CACHED_OBJECTS LIBLFS_DEF_N_CACHED_OBJECTS
+#endif
+
+#ifndef LIBLFS_LOOKAHEAD_SIZE
+#define LIBLFS_LOOKAHEAD_SIZE LIBLFS_DEF_LOOKAHEAD_SIZE
+#endif
+
+#ifndef LIBLFS_LINK_IS_RENAME
+#define LIBLFS_LINK_IS_RENAME LIBLFS_DEF_LINK_IS_RENAME
+#endif
+
+#ifndef LIBLFS_MOUNT_FORMAT_OPTION
+#define LIBLFS_MOUNT_FORMAT_OPTION LIBLFS_DEF_MOUNT_FORMAT_OPTION
+#endif
+
+#ifndef LIBLFS_FORMAT_ON_MOUNT_FAILURE
+#define LIBLFS_FORMAT_ON_MOUNT_FAILURE LIBLFS_DEF_FORMAT_ON_MOUNT_FAILURE
+#endif
+
 
 static int liblfs_create(void *info, oid_t *dir, const char *name, oid_t *oid, unsigned mode, int type, oid_t *dev)
 {
@@ -451,7 +483,7 @@ static int liblfs_setConfig(struct lfs_config *cfg, const char *args, size_t sto
 	cfg->block_count = storageSize / cfg->block_size;
 
 	/* Runtime configuration */
-	cfg->cache_size = LIBLFS_CACHESIZE_DEFAULT;
+	cfg->cache_size = LIBLFS_CACHESIZE;
 	cfg->lookahead_size = LIBLFS_LOOKAHEAD_SIZE;
 	cfg->block_cycles = LIBLFS_CYCLES_THRESHOLD;
 	cfg->ph.objectEvictThreshold = LIBLFS_N_CACHED_OBJECTS;


### PR DESCRIPTION
## Description
After discussion we decided that the best way to pass compile-time configuration to liblfs would be through `board_config.h`. To this end, `board_config.h` is now included in `liblfs.c`. Default configuration options are available through `#define`s in `liblfs.h` - may be useful when using `liblfs_rawcfg_mount`.

## Motivation and Context
JIRA: RTOS-686

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6-nucleo

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
