### PR TITLE
dummyfs: treat socket as otDev file

### DIFF
--- a/dummyfs/dir.c
+++ b/dummyfs/dir.c
@@ -164,6 +164,12 @@ int dummyfs_dir_add(dummyfs_t *ctx, dummyfs_object_t *dir, const char *name, uin
 	else if (S_ISLNK(mode)) {
 		n->type = DT_LNK;
 	}
+	else if (S_ISSOCK(mode)) {
+		n->type = DT_SOCK;
+	}
+	else if (S_ISFIFO(mode)) {
+		n->type = DT_FIFO;
+	}
 	else {
 		n->type = DT_UNKNOWN;
 	}

--- a/dummyfs/dummyfs.c
+++ b/dummyfs/dummyfs.c
@@ -37,6 +37,7 @@
 
 /* higher two bytes used as magic number */
 #define OBJECT_MODE_MEM (0xabad0000 | S_IFREG | S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
+#define DUMMYFS_ISDEV(mode) (S_ISCHR(mode) || S_ISBLK(mode) || S_ISFIFO(mode) || S_ISSOCK(mode))
 #define DUMMYFS_ROOTID  0
 
 
@@ -409,7 +410,7 @@ int dummyfs_getattr(void *ctx, oid_t *oid, int type, long long *attr)
 				else if (S_ISREG(o->mode)) {
 					*attr = otFile;
 				}
-				else if (S_ISCHR(o->mode) || S_ISBLK(o->mode) || S_ISFIFO(o->mode)) {
+				else if (DUMMYFS_ISDEV(o->mode)) {
 					*attr = otDev;
 				}
 				else if (S_ISLNK(o->mode)) {
@@ -486,7 +487,7 @@ int dummyfs_getattrAll(void *ctx, oid_t *oid, struct _attrAll *attrs)
 		else if (S_ISREG(o->mode)) {
 			attrs->type.val = otFile;
 		}
-		else if (S_ISCHR(o->mode) || S_ISBLK(o->mode) || S_ISFIFO(o->mode)) {
+		else if (DUMMYFS_ISDEV(o->mode)) {
 			attrs->type.val = otDev;
 		}
 		else if (S_ISLNK(o->mode)) {
@@ -712,7 +713,7 @@ static int _dummyfs_create(dummyfs_t *fs, oid_t *dir, const char *name, oid_t *o
 			break;
 
 		case otDev:
-			if (!(S_ISCHR(mode) || S_ISBLK(mode) || S_ISFIFO(mode))) {
+			if (!DUMMYFS_ISDEV(mode)) {
 				mode &= 0x1ff;
 				mode |= S_IFCHR;
 			}
@@ -749,7 +750,7 @@ static int _dummyfs_create(dummyfs_t *fs, oid_t *dir, const char *name, oid_t *o
 	o->atime = time(NULL);
 	o->mtime = o->atime;
 	o->ctime = o->atime;
-	o->dev = (S_ISCHR(mode) || S_ISBLK(mode) || S_ISFIFO(mode)) ? *dev : o->oid;
+	o->dev = (DUMMYFS_ISDEV(mode)) ? *dev : o->oid;
 
 	*oid = o->oid;
 

--- a/jffs2/libjffs2.c
+++ b/jffs2/libjffs2.c
@@ -21,6 +21,7 @@
 #include "include/libjffs2.h"
 
 #define TRACE(x, ...) printf("jffs trace: " x "\n", ##__VA_ARGS__)
+#define JFFS2_ISDEV(mode) (S_ISCHR(mode) || S_ISBLK(mode) || S_ISFIFO(mode) || S_ISSOCK(mode))
 
 
 jffs2_common_t jffs2_common;
@@ -340,7 +341,7 @@ static int libjffs2_getattr(void *info, oid_t *oid, int type, long long *attr)
 				*attr = otDir;
 			else if (S_ISREG(inode->i_mode))
 				*attr = otFile;
-			else if (S_ISCHR(inode->i_mode) || S_ISBLK(inode->i_mode) || S_ISFIFO(inode->i_mode))
+			else if (JFFS2_ISDEV(inode->i_mode))
 				*attr = otDev;
 			else if (S_ISLNK(inode->i_mode))
 				*attr = otSymlink;
@@ -421,7 +422,7 @@ static int libjffs2_getattrAll(void *info, oid_t *oid, struct _attrAll *attrs)
 	else if (S_ISREG(inode->i_mode)) {
 		attrs->type.val = otFile;
 	}
-	else if (S_ISCHR(inode->i_mode) || S_ISBLK(inode->i_mode) || S_ISFIFO(inode->i_mode)) {
+	else if (JFFS2_ISDEV(inode->i_mode)) {
 		attrs->type.val = otDev;
 	}
 	else if (S_ISLNK(inode->i_mode)) {
@@ -716,7 +717,7 @@ static int libjffs2_create(void *info, oid_t *dir, const char *name, oid_t *oid,
 			ret = idir->i_op->mkdir(idir, dentry, mode);
 			break;
 		case otDev:
-			if (!(S_ISCHR(mode) || S_ISBLK(mode) || S_ISFIFO(mode))) {
+			if (!JFFS2_ISDEV(mode)) {
 				mode &= ALLPERMS;
 				mode |= S_IFCHR;
 			}


### PR DESCRIPTION
RTOS-1385

<!--- Provide a general summary of your changes in the Title above -->
Socket is not treated as otDev file on dummyfs and jffs2. Now `stat()` shows proper mode.

Fixing phoenix-rtos/phoenix-rtos-project#749


## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
