### PR TITLE
jffs: remove bool type definitions

### DIFF
--- a/jffs2/phoenix-rtos/types.h
+++ b/jffs2/phoenix-rtos/types.h
@@ -18,14 +18,10 @@
 #define _OS_PHOENIX_TYPES_H_
 
 #include <sys/types.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #define pgoff_t unsigned long
-
-typedef uint8_t bool;
-
-#define true 1
-#define false 0
 
 typedef uint32_t u32;
 typedef uint16_t u16;


### PR DESCRIPTION
TASK: RTOS-1312

<!--- Provide a general summary of your changes in the Title above -->

## Description
gcc-15 changes default C version to gnu23 (so, c23 with extensions) [1]. This version of the standard adds "bool", "true" and "false" as keywords which cause compilation errors when one tries to define those symbols.

Remove those hand-rolled defines and use <stdbool.h>.

[1] https://gcc.gnu.org/gcc-15/changes.html#c

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
